### PR TITLE
3.0 Request • Menu Bar Icon Hidden functionality

### DIFF
--- a/Mos/AppDelegate.swift
+++ b/Mos/AppDelegate.swift
@@ -44,7 +44,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     // 在运行状态下再次运行则显示图标
     func applicationWillBecomeActive(_ aNotification: Notification) {
-        Options.shared.global.hideStatusItem = false
+        WindowManager.shared.showWindow(withIdentifier: WINDOW_IDENTIFIER.preferencesWindowController)
     }
     // 关闭前停止滚动处理
     func applicationWillTerminate(_ aNotification: Notification) {


### PR DESCRIPTION
Was playing with 3.0 on my local machine. Wanted to propose changing the dock icon/app launch functionality when the menu bar icon is hidden.
If the menu bar icon is hidden and you click the doc icon or try and launch the app from spotlight/finder, the preferences window is displayed. This would let users adjust the settings of Mos without having to unhide/rehide the menu bar icon.
Just an idea for consideration. Love the app, thank you for all your hard work!