### PR TITLE
Update brew install cmd and ru images url

### DIFF
--- a/README.enUS.md
+++ b/README.enUS.md
@@ -53,7 +53,7 @@ http://mos.caldis.me/
 If you wish to install the application from [Homebrew](https://brew.sh):
 
 ```bash
-$ brew cask install mos
+$ brew install mos --cask
 ```
 
 The application will live at `/Applications/Mos.app`.
@@ -62,7 +62,7 @@ To update the app:
 
 ```bash
 $ brew update
-$ brew cask reinstall mos
+$ brew reinstall mos --cask
 ```
 
 Quit then relaunch the app.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ http://mos.caldis.me/
 Mos可通过[Homebrew](https://brew.sh)来安装:
 
 ```bash
-$ brew cask install mos
+$ brew install mos --cask
 ```
 
 应用将被安装至 `/Applications/Mos.app`。
@@ -63,7 +63,7 @@ $ brew cask install mos
 
 ```bash
 $ brew update
-$ brew cask reinstall mos
+$ brew reinstall mos --cask
 ```
 
 重新启动应用即可。

--- a/README.ru.md
+++ b/README.ru.md
@@ -33,16 +33,16 @@ http://mos.caldis.me/
 ## Screenshot
 
 <p align="center">
-  <img width="600" src="https://github.com/mclvren/Mos/blob/master/docs/resources/image/ru/Mointor.png?raw=true">
+  <img width="600" src="https://github.com/Caldis/Mos/blob/master/docs/resources/image/ru/Mointor.png?raw=true">
 </p>
 <p align="center">
-  <img width="562" src="https://github.com/mclvren/Mos/blob/master/docs/resources/image/ru/PreferencesGeneral.png?raw=true">
+  <img width="562" src="https://github.com/Caldis/Mos/blob/master/docs/resources/image/ru/PreferencesGeneral.png?raw=true">
 </p>
 <p align="center">
-  <img width="562" src="https://github.com/mclvren/Mos/blob/master/docs/resources/image/ru/PreferencesAdvanced.png?raw=true">
+  <img width="562" src="https://github.com/Caldis/Mos/blob/master/docs/resources/image/ru/PreferencesAdvanced.png?raw=true">
 </p>
 <p align="center">
-  <img width="562" src="https://github.com/mclvren/Mos/blob/master/docs/resources/image/ru/PreferencesException.png?raw=true">
+  <img width="562" src="https://github.com/Caldis/Mos/blob/master/docs/resources/image/ru/PreferencesException.png?raw=true">
 </p>
 
 
@@ -53,7 +53,7 @@ http://mos.caldis.me/
 Если вы хотите установить приложение с помощью [Homebrew](https://brew.sh):
 
 ```bash
-$ brew cask install mos
+$ brew install mos --cask
 ```
 
 Приложение будет находится по адресу `/Applications/Mos.app`.
@@ -62,7 +62,7 @@ $ brew cask install mos
 
 ```bash
 $ brew update
-$ brew cask reinstall mos
+$ brew reinstall mos --cask
 ```
 
 Закройте и перезапустите приложение.


### PR DESCRIPTION
- Update install command by [Homebrew](https://brew.sh), using `--cask` flag instead of previous `cask`.
- Fix image url for Russian readme file.