### PR TITLE
Add Bahasa / Indonesian (id) translation

### DIFF
--- a/website/app/components/LanguageSelector/LanguageSelector.tsx
+++ b/website/app/components/LanguageSelector/LanguageSelector.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Modal } from "@/app/components/Modal";
-import { Language, useI18n } from "@/app/i18n/context";
-import { useModal } from "@/app/components/Modal/hooks";
+import { Modal } from '@/app/components/Modal';
+import { useModal } from '@/app/components/Modal/hooks';
+import { Language, useI18n } from '@/app/i18n/context';
 
 const LANGUAGES: {
   code: Language
@@ -18,6 +18,7 @@ const LANGUAGES: {
   { code: "el", name: "Ελληνικά" },
   { code: "tr", name: "Türkçe" },
   { code: "uk", name: "Українська" },
+  { code: "id", name: "Bahasa" },
 ];
 
 export function LanguageSelector() {

--- a/website/app/i18n/context.tsx
+++ b/website/app/i18n/context.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
-import { en } from "./en";
-import { zh } from "./zh";
-import { ru } from "./ru";
-import { tr } from "./tr";
-import { ko } from "./ko";
-import { de } from "./de";
-import { el } from "./el";
-import { uk } from "./uk";
-import { ja } from "./ja";
-import { zhHant } from "./zh-Hant";
+import { createContext, useContext, useEffect, useState } from 'react';
 
-export type Language = "en" | "zh" | "ru" | "tr" | "ko" | "de" | "el" | "uk" | "ja" | "zh-Hant";
+import { de } from './de';
+import { el } from './el';
+import { en } from './en';
+import { id } from './id';
+import { ja } from './ja';
+import { ko } from './ko';
+import { ru } from './ru';
+import { tr } from './tr';
+import { uk } from './uk';
+import { zh } from './zh';
+import { zhHant } from './zh-Hant';
+
+export type Language = "en" | "zh" | "ru" | "tr" | "ko" | "de" | "el" | "uk" | "ja" | "zh-Hant" | "id";
 export type Translations = typeof en;
 
 interface I18nContextType {
@@ -51,7 +53,8 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
       el,
       uk,
       ja,
-      "zh-Hant": zhHant
+      "zh-Hant": zhHant,
+      id,
     }[language] || en;
     setTranslations(translations);
     // 保存语言偏好到本地存储

--- a/website/app/i18n/id.ts
+++ b/website/app/i18n/id.ts
@@ -1,0 +1,14 @@
+export const id = {
+nav_docs: "dokumen",
+nav_github: "Github",
+hero_title: "Gulir lancar dengan Mos",
+hero_description: "Mos adalah alat canggih yang memungkinkan tetikus Anda menggulir lancar di macOS.",
+download_button: "Unduh Sekarang",
+download_releaseNotes: "Catatan Rilis",
+footer_systemRequirement: "Memerlukan macOS 10.13+",
+footer_installViaHomebrew: "Instal melalui homebrew",
+homebrew_title: "Instal melalui Homebrew",
+homebrew_description: "Jalankan perintah berikut di terminal Anda:",
+homebrew_copy: "Salin",
+homebrew_copied: "Disalin!"
+}


### PR DESCRIPTION
Hi Caldis
I added an Indonesian translation for the Mos website.

**Changes included:**

- Added id.ts in the locales folder with all keys translated from English to Indonesian.
- Ensured that all keys from en.ts are also present in id.ts (no missing translations).
- Updated the Language type and translation mapping in the provider to include "id".

**Why this matters:**

- Makes Mos more accessible and user-friendly for Indonesian users.
- Expands the project’s global reach and improves inclusivity.

**Checks done:**

- Switched the language to “Indonesian” and verified the UI updates correctly.
- Confirmed that buttons, links, and navigation continue to work after the translation.
- Thank you for building this great project and allowing the community to contribute! 🎉

**Screenhot**

-Select Langunge (bahasa)
<img width="3600" height="2004" alt="image" src="https://github.com/user-attachments/assets/ca385603-7f2b-4f27-8d0b-264cafd5e88a" />
-Selected Bahasa
<img width="3600" height="2004" alt="image" src="https://github.com/user-attachments/assets/43d1f9cc-09fc-4fe2-ac46-345ebf24bd58" />

Best regards,
Harunal Rosyid