### PR TITLE
Allow middle mouse button mapping without modifier keys

### DIFF
--- a/Mos/Keys/KeyCode.swift
+++ b/Mos/Keys/KeyCode.swift
@@ -163,5 +163,5 @@ struct KeyCode {
         14: "🖱14", 15: "🖱15", 16: "🖱16", 17: "🖱17", 18: "🖱18",
         19: "🖱19", 20: "🖱20"
     ]
-    static let mouseMainKeys: [UInt16] = [0,1,2]
+    static let mouseMainKeys: [UInt16] = [0,1]  // Only protect left/right clicks, allow middle button without modifiers
 }


### PR DESCRIPTION
## Problem

Currently, the middle mouse button (button 2) cannot be mapped to shortcuts without holding modifier keys (Cmd, Ctrl, Option, Shift). When users try to record the middle button alone, the UI shows an orange shake and rejects the input.

This happens because button 2 is classified as a "main key" in `KeyCode.mouseMainKeys` alongside left (0) and right (1) clicks, and the validation in `CGEvent+Extensions.swift` requires modifier keys for all main keys.

## Solution

Remove button 2 from the `mouseMainKeys` array, allowing users to map their middle mouse button without holding modifiers, while still protecting left and right clicks from accidental remapping.

**Changed:**
```swift
// Before
static let mouseMainKeys: [UInt16] = [0,1,2]

// After  
static let mouseMainKeys: [UInt16] = [0,1]  // Only protect left/right clicks, allow middle button without modifiers
```

## Use Case

Mapping the middle mouse button to Mission Control (or App Exposé, Show Desktop, etc.) is a very common mouse customization pattern. This is a primary use case mentioned in issue #695 and is supported by other mouse customization tools.

## Testing

- ✅ Middle button can now be recorded without modifiers
- ✅ Successfully maps to Mission Control and other shortcuts
- ✅ Left and right clicks still require modifiers (protected)
- ✅ Other mouse buttons (3+) work as before

## Related Issues

- Addresses use case from #695 (Feature Request: Mouse Button Customization)
- Related to #814 (Per application button configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)