### PR TITLE
Revert `Cmd+[` / `Cmd+]` and Add Begin/End of Line actions

### DIFF
--- a/Mos/Localizable.xcstrings
+++ b/Mos/Localizable.xcstrings
@@ -3560,6 +3560,172 @@
         }
       }
     },
+    "beginOfLine" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anfang der Zeile / Zurück"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Αρχή Γραμμής / Πίσω"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Begin of Line / Back"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Début de Ligne / Précédent"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行頭へ / 戻る"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "줄 시작 / 뒤로"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Начало строки / Назад"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Satır Başı / Geri"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Початок рядка / Назад"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行首 / 后退"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行首 / 返回"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行首 / 返回"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行首 / 返回"
+          }
+        }
+      }
+    },
+    "endOfLine" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ende der Zeile / Vorwärts"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Τέλος Γραμμής / Εμπρός"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "End of Line / Forward"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fin de Ligne / Suivant"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行末へ / 進む"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "줄 끝 / 앞으로"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конец строки / Вперед"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Satır Sonu / İleri"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кінець рядка / Вперед"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行尾 / 前进"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行尾 / 前進"
+          }
+        },
+        "zh-Hant-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行尾 / 前進"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行尾 / 前進"
+          }
+        }
+      }
+    },
     "Needs access to Accessibility controls" : {
       "localizations" : {
         "de" : {

--- a/Mos/Shortcut/SystemShortcut.swift
+++ b/Mos/Shortcut/SystemShortcut.swift
@@ -100,6 +100,8 @@ struct SystemShortcut {
                 // 标签与导航
                 case "navigateBack": return "chevron.backward"
                 case "navigateForward": return "chevron.forward"
+                case "beginOfLine": return "arrow.left.to.line"
+                case "endOfLine": return "arrow.right.to.line"
                 case "nextTab": return "rectangle.on.rectangle"
                 case "previousTab": return "rectangle.fill.on.rectangle.fill"
                 case "switchTabRight": return "arrow.right.circle"
@@ -224,12 +226,14 @@ struct SystemShortcut {
     static let closeAllWindows = Shortcut("closeAllWindows", 13, [.command, .option])  // Command-Option-W
     static let quitApp = Shortcut("quitApp", 12, .command)  // Command-Q
 
-    // FIX: Back/Forward - Use Command + Arrow Keys
+    // Navigation: Back/Forward with brackets
+    static let navigateBack = Shortcut("navigateBack", 33, .command)  // Command-[ (Left Bracket)
+    static let navigateForward = Shortcut("navigateForward", 30, .command)  // Command-] (Right Bracket)
+    // FIX: Back/Forward - Use Command + Arrow Keys, which can also be used as navigateBack and navigateForward.
     // Replaces Brackets (33/30) which are broken on German keyboards.
-    static let navigateBack = Shortcut("navigateBack", 123, .command)  // Command-LeftArrow
-    static let navigateForward = Shortcut("navigateForward", 124, .command)  // Command-RightArrow
-    // FIX: Next/Prev Tab - Use Command + Shift + Arrow Keys
-    // Replaces Command+Shift+Brackets.
+    static let beginOfLine = Shortcut("beginOfLine", 123, .command)  // Command-LeftArrow (Begin of line / Back)
+    static let endOfLine = Shortcut("endOfLine", 124, .command)  // Command-RightArrow (End of line / Forward)
+    // Tab navigation
     static let nextTab = Shortcut("nextTab", 124, [.command, .shift])  // Command-Shift-RightArrow
     static let previousTab = Shortcut("previousTab", 123, [.command, .shift])  // Command-Shift-LeftArrow
     static let switchTabRight = Shortcut("switchTabRight", 124, [.command, .option])  // Command-Option-Right
@@ -269,6 +273,7 @@ struct SystemShortcut {
         "closeAllWindows": closeAllWindows, "quitApp": quitApp,
         // 标签导航
         "navigateBack": navigateBack, "navigateForward": navigateForward,
+        "beginOfLine": beginOfLine, "endOfLine": endOfLine,
         "nextTab": nextTab, "previousTab": previousTab,
         "switchTabLeft": switchTabLeft, "switchTabRight": switchTabRight,
         // 辅助功能
@@ -324,7 +329,7 @@ struct SystemShortcut {
             screenshot, screenshotSelection, screenshotAndRecording
         ]),
         ("categoryNavigation", [
-            navigateBack, navigateForward, previousTab, nextTab, switchTabLeft, switchTabRight
+            navigateBack, navigateForward, beginOfLine, endOfLine, previousTab, nextTab, switchTabLeft, switchTabRight
         ]),
         // ("categoryAccessibility", [  // 暂时不提供, 有问题
         //     invertColors, zoomIn, zoomOut


### PR DESCRIPTION
## Improve keyboard shortcuts: Revert `Cmd+[` / `Cmd+]` and Add Begin/End of Line actions

This PR extends the keyboard layout fix from #827 by repurposing the arrow key shortcuts and reintroducing bracket-based navigation.

### Changes:

- **Back/Forward**: Changed back to `Cmd+[` / `Cmd+]` (bracket keys)
- **Begin of Line / End of Line**: Now uses `Cmd+←` / `Cmd+→` (arrow keys)

`Cmd+[` / `Cmd+]` have better compatibility. For instance, navigating in Finder.