### PR TITLE
updated READMEs to use mos@beta homebrew cask

### DIFF
--- a/README.enUS.md
+++ b/README.enUS.md
@@ -46,7 +46,7 @@ http://mos.caldis.me/
 If you wish to install the application from [Homebrew](https://brew.sh):
 
 ```bash
-$ brew install --cask mos
+$ brew install --cask mos@beta
 ```
 
 The application will live at `/Applications/Mos.app`.
@@ -55,7 +55,7 @@ To update the app:
 
 ```bash
 $ brew update
-$ brew reinstall mos
+$ brew upgrade mos@beta
 ```
 
 Quit then relaunch the app.

--- a/README.id.md
+++ b/README.id.md
@@ -39,7 +39,7 @@ http://mos.caldis.me/
 Kalau kamu mau instal aplikasi ini lewat [Homebrew](https://brew.sh):
 
 ```bash
-$ brew install --cask mos
+$ brew install --cask mos@beta
 ```
 
 Aplikasi ada di `/Applications/Mos.app`.
@@ -48,7 +48,7 @@ Untuk Update Aplikasi
 
 ```bash
 $ brew update
-$ brew reinstall mos
+$ brew upgrade mos@beta
 ```
 
 Keluar dan jalankan lagi aplikasi

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ http://mos.caldis.me/
 Mos可通过[Homebrew](https://brew.sh)来安装:
 
 ```bash
-$ brew install --cask mos
+$ brew install --cask mos@beta
 ```
 
 应用将被安装至 `/Applications/Mos.app`。
@@ -45,7 +45,7 @@ $ brew install --cask mos
 
 ```bash
 $ brew update
-$ brew reinstall mos
+$ brew upgrade mos@beta
 ```
 
 重新启动应用即可。

--- a/README.ru.md
+++ b/README.ru.md
@@ -46,7 +46,7 @@ http://mos.caldis.me/
 Если вы хотите установить приложение с помощью [Homebrew](https://brew.sh):
 
 ```bash
-$ brew install --cask mos
+$ brew install --cask mos@beta
 ```
 
 Приложение будет находится по адресу `/Applications/Mos.app`.
@@ -55,7 +55,7 @@ $ brew install --cask mos
 
 ```bash
 $ brew update
-$ brew reinstall mos
+$ brew upgrade mos@beta
 ```
 
 Закройте и перезапустите приложение.


### PR DESCRIPTION
应 https://github.com/Caldis/Mos/issues/824 的内容，已通过 https://github.com/Homebrew/homebrew-cask/pull/245519 向 homebrew casks 添加了 mos beta 版。鉴于 homebrew cask 的 mos 正式版依旧停留在 3.5.0，推荐更新 README 引导用户安装最新的 beta 版