### PR TITLE
Ignore transient opposite scroll pulses before reversing

### DIFF
--- a/Mos/ScrollCore/ScrollPoster.swift
+++ b/Mos/ScrollCore/ScrollPoster.swift
@@ -9,6 +9,23 @@
 import Cocoa
 import os
 
+enum ScrollAxisInputDecision: Equatable {
+    case noInput
+    case acceptedContinuation
+    case acceptedReversal
+    case ignoredOppositePulse
+}
+
+struct ScrollReverseCandidateState: Equatable {
+    var sign = 0.0
+    var count = 0
+
+    mutating func clear() {
+        sign = 0.0
+        count = 0
+    }
+}
+
 class ScrollPoster {
 
     // 单例
@@ -23,6 +40,8 @@ class ScrollPoster {
     private var current = (y: 0.0, x: 0.0)  // 当前滚动距离
     private var delta = (y: 0.0, x: 0.0)  // 滚动方向记录
     private var buffer = (y: 0.0, x: 0.0)  // 滚动缓冲距离
+    private var reverseCandidateY = ScrollReverseCandidateState()
+    private var reverseCandidateX = ScrollReverseCandidateState()
     // 滚动配置
     private var shifting = false
     private var duration = Options.shared.scroll.durationTransition
@@ -38,6 +57,7 @@ class ScrollPoster {
     private let manualSeparationThreshold: CFTimeInterval = 0.45
     private let trackingEndAdvance: CFTimeInterval = 0.04
     private let momentumEndDelay: CFTimeInterval = 0.13
+    private let reverseConfirmationCount = 2
     // 状态锁和投递上下文
     private var stateLock = os_unfair_lock_s()
     private let dispatchContext = ScrollDispatchContext.shared
@@ -52,6 +72,53 @@ class ScrollPoster {
 
 // MARK: - 滚动数据更新控制
 extension ScrollPoster {
+    @discardableResult
+    func resolveAxisInput(
+        input: Double,
+        speed: Double,
+        amplification: Double,
+        deadZone: Double,
+        current: inout Double,
+        buffer: inout Double,
+        delta: inout Double,
+        reverseCandidate: inout ScrollReverseCandidateState
+    ) -> ScrollAxisInputDecision {
+        guard input != 0.0 else {
+            reverseCandidate.clear()
+            return .noInput
+        }
+
+        let sign = input.sign == .minus ? -1.0 : 1.0
+        let acceptedSign = delta == 0.0 ? 0.0 : (delta.sign == .minus ? -1.0 : 1.0)
+        let isDirectionFlip = acceptedSign != 0.0 && sign != acceptedSign
+        let activeResidual = max((buffer - current).magnitude, current.magnitude) > deadZone
+
+        if isDirectionFlip && activeResidual {
+            if reverseCandidate.sign == sign {
+                reverseCandidate.count += 1
+            } else {
+                reverseCandidate.sign = sign
+                reverseCandidate.count = 1
+            }
+            if reverseCandidate.count < reverseConfirmationCount {
+                return .ignoredOppositePulse
+            }
+        }
+
+        reverseCandidate.clear()
+
+        if input * delta > 0 {
+            buffer += input * speed * amplification
+            delta = input
+            return .acceptedContinuation
+        } else {
+            buffer = input * speed * amplification
+            current = 0.0
+            delta = input
+            return isDirectionFlip ? .acceptedReversal : .acceptedContinuation
+        }
+    }
+
     func update(event: CGEvent, duration: Double, y: Double, x: Double, speed: Double, amplification: Double = 1) -> Self {
         guard dispatchContext.capture(event: event) else {
             return self
@@ -60,21 +127,45 @@ extension ScrollPoster {
         defer { os_unfair_lock_unlock(&stateLock) }
         // 更新滚动配置
         self.duration = duration
+        let deadZone = Options.shared.scroll.deadZone
         // 更新滚动数据
-        if y*delta.y > 0 {
-            buffer.y += y * speed * amplification
-        } else {
-            buffer.y = y * speed * amplification
-            current.y = 0.0
+        let yDecision = resolveAxisInput(
+            input: y,
+            speed: speed,
+            amplification: amplification,
+            deadZone: deadZone,
+            current: &current.y,
+            buffer: &buffer.y,
+            delta: &delta.y,
+            reverseCandidate: &reverseCandidateY
+        )
+        let xDecision = resolveAxisInput(
+            input: x,
+            speed: speed,
+            amplification: amplification,
+            deadZone: deadZone,
+            current: &current.x,
+            buffer: &buffer.x,
+            delta: &delta.x,
+            reverseCandidate: &reverseCandidateX
+        )
+
+        if yDecision == .acceptedReversal || xDecision == .acceptedReversal {
+            // Prevent stale opposite-direction tail from leaking into the new run.
+            filter.reset()
         }
-        if x*delta.x > 0 {
-            buffer.x += x * speed * amplification
-        } else {
-            buffer.x = x * speed * amplification
-            current.x = 0.0
-        }
-        delta = (y: y, x: x)
+
         let now = CFAbsoluteTimeGetCurrent()
+        let acceptedAny = yDecision == .acceptedContinuation || yDecision == .acceptedReversal
+            || xDecision == .acceptedContinuation || xDecision == .acceptedReversal
+        if !acceptedAny {
+            if !manualInputEnded {
+                lastManualEventTime = now
+                trackingEndScheduledTime = nil
+            }
+            return self
+        }
+
         let interval = lastManualEventTime > 0.0 ? now - lastManualEventTime : nil
         let separatedByTime = interval == nil ? true : interval! >= manualSeparationThreshold
         let phase = ScrollPhase.shared.phase
@@ -140,6 +231,8 @@ extension ScrollPoster {
         current = ( y: 0.0, x: 0.0 )
         delta = ( y: 0.0, x: 0.0 )
         buffer = ( y: 0.0, x: 0.0 )
+        reverseCandidateY.clear()
+        reverseCandidateX.clear()
         // 重置插值器
         filter.reset()
         ScrollPhase.shared.reset()

--- a/MosTests/ScrollPosterStateTests.swift
+++ b/MosTests/ScrollPosterStateTests.swift
@@ -22,6 +22,104 @@ final class ScrollPosterStateTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - resolveAxisInput
+
+    func testResolveAxisInput_sameDirection_accumulatesBuffer() {
+        var current = 10.0
+        var buffer = 50.0
+        var delta = 12.0
+        var reverseCandidate = ScrollReverseCandidateState()
+
+        let decision = sut.resolveAxisInput(
+            input: 8.0,
+            speed: 2.0,
+            amplification: 1.0,
+            deadZone: 1.0,
+            current: &current,
+            buffer: &buffer,
+            delta: &delta,
+            reverseCandidate: &reverseCandidate
+        )
+
+        XCTAssertEqual(decision, .acceptedContinuation)
+        XCTAssertEqual(current, 10.0, accuracy: 1e-10)
+        XCTAssertEqual(buffer, 66.0, accuracy: 1e-10)
+        XCTAssertEqual(delta, 8.0, accuracy: 1e-10)
+        XCTAssertEqual(reverseCandidate, ScrollReverseCandidateState())
+    }
+
+    func testResolveAxisInput_firstOppositePulseWhileActive_isIgnored() {
+        var current = 40.0
+        var buffer = 100.0
+        var delta = 12.0
+        var reverseCandidate = ScrollReverseCandidateState()
+
+        let decision = sut.resolveAxisInput(
+            input: -8.0,
+            speed: 2.0,
+            amplification: 1.0,
+            deadZone: 1.0,
+            current: &current,
+            buffer: &buffer,
+            delta: &delta,
+            reverseCandidate: &reverseCandidate
+        )
+
+        XCTAssertEqual(decision, .ignoredOppositePulse)
+        XCTAssertEqual(current, 40.0, accuracy: 1e-10)
+        XCTAssertEqual(buffer, 100.0, accuracy: 1e-10)
+        XCTAssertEqual(delta, 12.0, accuracy: 1e-10)
+        XCTAssertEqual(reverseCandidate.sign, -1.0, accuracy: 1e-10)
+        XCTAssertEqual(reverseCandidate.count, 1)
+    }
+
+    func testResolveAxisInput_secondOppositePulseWhileActive_acceptsReversal() {
+        var current = 40.0
+        var buffer = 100.0
+        var delta = 12.0
+        var reverseCandidate = ScrollReverseCandidateState(sign: -1.0, count: 1)
+
+        let decision = sut.resolveAxisInput(
+            input: -8.0,
+            speed: 2.0,
+            amplification: 1.0,
+            deadZone: 1.0,
+            current: &current,
+            buffer: &buffer,
+            delta: &delta,
+            reverseCandidate: &reverseCandidate
+        )
+
+        XCTAssertEqual(decision, .acceptedReversal)
+        XCTAssertEqual(current, 0.0, accuracy: 1e-10)
+        XCTAssertEqual(buffer, -16.0, accuracy: 1e-10)
+        XCTAssertEqual(delta, -8.0, accuracy: 1e-10)
+        XCTAssertEqual(reverseCandidate, ScrollReverseCandidateState())
+    }
+
+    func testResolveAxisInput_oppositePulseWithoutResidual_acceptsImmediately() {
+        var current = 0.0
+        var buffer = 0.0
+        var delta = 12.0
+        var reverseCandidate = ScrollReverseCandidateState()
+
+        let decision = sut.resolveAxisInput(
+            input: -8.0,
+            speed: 2.0,
+            amplification: 1.0,
+            deadZone: 1.0,
+            current: &current,
+            buffer: &buffer,
+            delta: &delta,
+            reverseCandidate: &reverseCandidate
+        )
+
+        XCTAssertEqual(decision, .acceptedReversal)
+        XCTAssertEqual(current, 0.0, accuracy: 1e-10)
+        XCTAssertEqual(buffer, -16.0, accuracy: 1e-10)
+        XCTAssertEqual(delta, -8.0, accuracy: 1e-10)
+    }
+
     // MARK: - shift: shifting = false (默认)
 
     func testShift_whenNotShifting_passThrough() {


### PR DESCRIPTION
## Summary
Improve scroll smoothing stability by requiring confirmation before treating a brief opposite-direction pulse as a real reversal.

## Related issue
- likely addresses #568 (`scroll bounce back`), where users report one-direction scrolling occasionally reversing or bouncing back

## What changed
- add per-axis reversal candidate tracking in ScrollPoster
- ignore the first opposite pulse while residual scroll is still active
- accept reversal on the next matching opposite pulse and reset the smoothing filter
- add focused tests for continuation, ignored opposite pulse, confirmed reversal, and immediate reversal without residual momentum

## Root cause
Mos previously reset scroll direction immediately when any opposite-direction input arrived. On some mice, a transient opposite pulse can appear during fast wheel motion. That single pulse was enough to reset the scroll buffer and produce a visible reverse spike.

## Validation
- built patched release Mos.app locally with Xcode 26.4
- installed the patched app over the local Mos.app and verified it launches
- manual testing on the target machine no longer reproduces the random reverse-scroll spike

## Notes
This keeps intentional direction changes working, but adds a small confirmation guard while residual smooth-scroll output is still active.
