### PR TITLE
Fix reverse flag comparison typo in scroll options equality

### DIFF
--- a/Mos/Utils/Constants.swift
+++ b/Mos/Utils/Constants.swift
@@ -182,7 +182,7 @@ extension OPTIONS_SCROLL_DEFAULT: Equatable {
     static func == (l: OPTIONS_SCROLL_DEFAULT, r: OPTIONS_SCROLL_DEFAULT) -> Bool {
         return (
             l.smooth == r.smooth &&
-            l.reverse == r.smooth &&
+            l.reverse == r.reverse &&
             l.reverseVertical == r.reverseVertical &&
             l.reverseHorizontal == r.reverseHorizontal &&
             l.dash == r.dash &&


### PR DESCRIPTION
## Summary
Fix a typo in `OPTIONS_SCROLL_DEFAULT` equality comparison.

## What changed
- compare `l.reverse` with `r.reverse` instead of `r.smooth`

## Why it matters
The current `Equatable` implementation compares the reverse-scroll flag on the left-hand side against the smooth-scroll flag on the right-hand side. That can produce incorrect equality results when scroll option snapshots are compared.

## Validation
- inspected the diff to ensure this PR only changes the mistaken comparison line
- no behavioral changes outside the equality check