### PR TITLE
Fix ToDesk remote scroll passthrough

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -7,7 +7,7 @@ on:
       - fix/todesk-remote-scroll
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: build-installer-${{ github.ref }}
@@ -18,6 +18,8 @@ jobs:
     name: Build unsigned DMG
     runs-on: macos-26
     timeout-minutes: 30
+    env:
+      SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
 
     steps:
       - name: Check out source
@@ -32,7 +34,15 @@ jobs:
         run: |
           xcodebuild -resolvePackageDependencies \
             -project Mos.xcodeproj \
-            -scheme Debug
+            -scheme Debug \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData"
+
+      - name: Compute unique build number
+        id: version
+        run: |
+          BUILD="$(date +%Y%m%d).${GITHUB_RUN_NUMBER}"
+          echo "build=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "Using CURRENT_PROJECT_VERSION=$BUILD"
 
       - name: Build release archive
         run: |
@@ -45,6 +55,7 @@ jobs:
             -derivedDataPath "$RUNNER_TEMP/DerivedData" \
             ARCHS="arm64 x86_64" \
             ONLY_ACTIVE_ARCH=NO \
+            CURRENT_PROJECT_VERSION="${{ steps.version.outputs.build }}" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO
 
@@ -70,8 +81,15 @@ jobs:
           VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$INFO_PLIST")
           BUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$INFO_PLIST")
           DMG_NAME="Mos.${VERSION}-${BUILD}-unsigned.dmg"
+          ZIP_NAME="Mos.Versions.${VERSION}-${BUILD}.zip"
+          TAG="fork-${VERSION}-${BUILD}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "build=$BUILD" >> "$GITHUB_OUTPUT"
           echo "dmg_name=$DMG_NAME" >> "$GITHUB_OUTPUT"
           echo "dmg_path=$RUNNER_TEMP/$DMG_NAME" >> "$GITHUB_OUTPUT"
+          echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
+          echo "zip_path=$RUNNER_TEMP/$ZIP_NAME" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "artifact_name=Mos-${VERSION}-${BUILD}-unsigned" >> "$GITHUB_OUTPUT"
 
       - name: Create installer DMG
@@ -109,3 +127,91 @@ jobs:
           if-no-files-found: error
           compression-level: 0
           retention-days: 7
+
+      - name: Package Sparkle zip
+        run: |
+          APP_PATH="$RUNNER_TEMP/Mos.xcarchive/Products/Applications/Mos.app"
+          ditto -c -k --norsrc --noextattr --keepParent "$APP_PATH" "${{ steps.metadata.outputs.zip_path }}"
+          zipinfo -1 "${{ steps.metadata.outputs.zip_path }}" | grep '/\._' && {
+            echo "ERROR: AppleDouble files found in zip"
+            exit 1
+          } || echo "OK: no AppleDouble files"
+
+      - name: Sign and publish fork Sparkle update
+        if: ${{ env.SPARKLE_PRIVATE_KEY != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ZIP_PATH="${{ steps.metadata.outputs.zip_path }}"
+          ZIP_NAME="${{ steps.metadata.outputs.zip_name }}"
+          VERSION="${{ steps.metadata.outputs.version }}"
+          BUILD="${{ steps.metadata.outputs.build }}"
+          TAG="${{ steps.metadata.outputs.tag }}"
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${ZIP_NAME}"
+
+          SIGN_UPDATE=$(find "$RUNNER_TEMP/DerivedData" -path "*/artifacts/sparkle/Sparkle/bin/sign_update" -type f | head -1)
+          if [[ -z "$SIGN_UPDATE" ]]; then
+            SIGN_UPDATE=$(find "$RUNNER_TEMP/DerivedData" -name sign_update -type f | head -1)
+          fi
+          test -n "$SIGN_UPDATE"
+          chmod +x "$SIGN_UPDATE"
+
+          SIGN_OUTPUT=$(printf '%s' "$SPARKLE_PRIVATE_KEY" | "$SIGN_UPDATE" --ed-key-file - "$ZIP_PATH")
+          echo "$SIGN_OUTPUT"
+          ED_SIGNATURE=$(echo "$SIGN_OUTPUT" | grep -o 'sparkle:edSignature="[^"]*"' | sed 's/sparkle:edSignature="//;s/"//')
+          FILE_LENGTH=$(echo "$SIGN_OUTPUT" | grep -o 'length="[^"]*"' | sed 's/length="//;s/"//')
+          test -n "$ED_SIGNATURE"
+          test -n "$FILE_LENGTH"
+
+          NOTES=$(git log -1 --pretty=%B | sed 's/]]>/]]]]><![CDATA[>/g')
+          CHANGELOG="<h2>更新</h2><ul><li>${NOTES}</li></ul>"
+          PUB_DATE=$(date -u "+%a, %d %b %Y %H:%M:%S +0000")
+          export NEW_ITEM
+          NEW_ITEM=$(cat <<EOF
+              <item>
+                <title>Mos ${VERSION}</title>
+                <description><![CDATA[${CHANGELOG}]]></description>
+                <pubDate>${PUB_DATE}</pubDate>
+                <enclosure
+                  url="${DOWNLOAD_URL}"
+                  length="${FILE_LENGTH}"
+                  type="application/octet-stream"
+                  sparkle:shortVersionString="${VERSION}"
+                  sparkle:version="${BUILD}"
+                  sparkle:edSignature="${ED_SIGNATURE}"
+                />
+              </item>
+          EOF
+          )
+
+          BASE_APPCAST=""
+          if gh release view sparkle-feed >/dev/null 2>&1; then
+            mkdir -p "$RUNNER_TEMP/old-feed"
+            gh release download sparkle-feed --pattern appcast.xml --dir "$RUNNER_TEMP/old-feed" || true
+            if [[ -f "$RUNNER_TEMP/old-feed/appcast.xml" ]]; then
+              BASE_APPCAST="$RUNNER_TEMP/old-feed/appcast.xml"
+            fi
+          fi
+
+          python3 scripts/generate-fork-appcast.py "${BASE_APPCAST:--}" "$BUILD" > "$RUNNER_TEMP/appcast.xml"
+
+          gh release create "$TAG" \
+            --title "Mos ${VERSION} (${BUILD})" \
+            --notes "$NOTES" \
+            --target "$GITHUB_SHA" \
+            "$ZIP_PATH"
+
+          if gh release view sparkle-feed >/dev/null 2>&1; then
+            gh release upload sparkle-feed "$RUNNER_TEMP/appcast.xml" --clobber
+          else
+            gh release create sparkle-feed \
+              --title "Sparkle feed" \
+              --notes "Independent update feed for this fork. Not affiliated with the upstream Caldis/Mos appcast." \
+              --target "$GITHUB_SHA" \
+              "$RUNNER_TEMP/appcast.xml"
+          fi
+
+      - name: Skip Sparkle publish
+        if: ${{ env.SPARKLE_PRIVATE_KEY == '' }}
+        run: echo "SPARKLE_PRIVATE_KEY secret is missing; installer artifact was still uploaded."

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,0 +1,99 @@
+name: Build macOS installer
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fix/todesk-remote-scroll
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-installer-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-installer:
+    name: Build unsigned DMG
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v6
+
+      - name: Show build environment
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Mos.xcodeproj \
+            -scheme Debug
+
+      - name: Build release archive
+        run: |
+          xcodebuild archive \
+            -project Mos.xcodeproj \
+            -scheme Debug \
+            -configuration Release \
+            -destination "generic/platform=macOS" \
+            -archivePath "$RUNNER_TEMP/Mos.xcarchive" \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Apply ad-hoc signature
+        run: |
+          APP_PATH="$RUNNER_TEMP/Mos.xcarchive/Products/Applications/Mos.app"
+          test -d "$APP_PATH"
+          codesign --force --deep --sign - --options runtime "$APP_PATH"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          lipo -archs "$APP_PATH/Contents/MacOS/Mos"
+
+      - name: Read package metadata
+        id: metadata
+        run: |
+          APP_PATH="$RUNNER_TEMP/Mos.xcarchive/Products/Applications/Mos.app"
+          INFO_PLIST="$APP_PATH/Contents/Info.plist"
+          VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$INFO_PLIST")
+          BUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$INFO_PLIST")
+          DMG_NAME="Mos.${VERSION}-${BUILD}-unsigned.dmg"
+          echo "dmg_name=$DMG_NAME" >> "$GITHUB_OUTPUT"
+          echo "dmg_path=$RUNNER_TEMP/$DMG_NAME" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=Mos-${VERSION}-${BUILD}-unsigned" >> "$GITHUB_OUTPUT"
+
+      - name: Create installer DMG
+        run: |
+          APP_PATH="$RUNNER_TEMP/Mos.xcarchive/Products/Applications/Mos.app"
+          DMG_ROOT="$RUNNER_TEMP/dmg-root"
+          mkdir -p "$DMG_ROOT"
+          ditto --norsrc --noextattr "$APP_PATH" "$DMG_ROOT/Mos.app"
+          ln -s /Applications "$DMG_ROOT/Applications"
+          hdiutil create \
+            -volname Mos \
+            -srcfolder "$DMG_ROOT" \
+            -format UDZO \
+            -ov \
+            "${{ steps.metadata.outputs.dmg_path }}"
+
+      - name: Verify installer
+        run: |
+          DMG_PATH="${{ steps.metadata.outputs.dmg_path }}"
+          test -s "$DMG_PATH"
+          hdiutil verify "$DMG_PATH"
+          shasum -a 256 "$DMG_PATH"
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.metadata.outputs.artifact_name }}
+          path: ${{ steps.metadata.outputs.dmg_path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -52,8 +52,14 @@ jobs:
         run: |
           APP_PATH="$RUNNER_TEMP/Mos.xcarchive/Products/Applications/Mos.app"
           test -d "$APP_PATH"
-          codesign --force --deep --sign - --options runtime "$APP_PATH"
+          codesign --force --deep --sign - "$APP_PATH"
           codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          SIGNATURE_INFO=$(codesign -dvv "$APP_PATH" 2>&1)
+          echo "$SIGNATURE_INFO"
+          if [[ "$SIGNATURE_INFO" == *runtime* ]]; then
+            echo "Ad-hoc builds must not enable Hardened Runtime because embedded frameworks have no shared Team ID."
+            exit 1
+          fi
           lipo -archs "$APP_PATH/Contents/MacOS/Mos"
 
       - name: Read package metadata
@@ -85,8 +91,14 @@ jobs:
       - name: Verify installer
         run: |
           DMG_PATH="${{ steps.metadata.outputs.dmg_path }}"
+          MOUNT_PATH="$RUNNER_TEMP/dmg-mount"
           test -s "$DMG_PATH"
           hdiutil verify "$DMG_PATH"
+          mkdir -p "$MOUNT_PATH"
+          hdiutil attach "$DMG_PATH" -mountpoint "$MOUNT_PATH" -nobrowse -readonly
+          trap 'hdiutil detach "$MOUNT_PATH"' EXIT
+          codesign --verify --deep --strict --verbose=2 "$MOUNT_PATH/Mos.app"
+          lipo -archs "$MOUNT_PATH/Mos.app/Contents/MacOS/Mos"
           shasum -a 256 "$DMG_PATH"
 
       - name: Upload installer

--- a/Mos/Info.plist
+++ b/Mos/Info.plist
@@ -47,8 +47,8 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>
-	<string>https://mos.caldis.me/appcast.xml</string>
+	<string>https://github.com/ZHOUSJ6/Mos/releases/download/sparkle-feed/appcast.xml</string>
 	<key>SUPublicEDKey</key>
-	<string>zskqekl7thqvIANuR8SLKrfQ4LpqsZckKiDWfcD86JQ=</string>
+	<string>ZIPGVBhcI0PGAJV0+nYtILxcZGj95CSm77+w4tyYxkk=</string>
 </dict>
 </plist>

--- a/Mos/Managers/UpdateManager.swift
+++ b/Mos/Managers/UpdateManager.swift
@@ -10,6 +10,8 @@ import Sparkle
 final class UpdateManager: NSObject {
 
     static let shared = UpdateManager()
+    /// 本 fork 独立更新源，不走原项目 mos.caldis.me
+    static let forkAppcastURL = "https://github.com/ZHOUSJ6/Mos/releases/download/sparkle-feed/appcast.xml"
 
     private lazy var updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
@@ -43,6 +45,10 @@ extension UpdateManager {
 }
 
 extension UpdateManager: SPUUpdaterDelegate {
+
+    func feedURLString(for updater: SPUUpdater) -> String? {
+        return UpdateManager.forkAppcastURL
+    }
 
     func allowedChannels(for updater: SPUUpdater) -> Set<String> {
         Options.shared.update.includingBetaVersion ? ["beta"] : []

--- a/Mos/ScrollCore/ScrollCore.swift
+++ b/Mos/ScrollCore/ScrollCore.swift
@@ -82,13 +82,18 @@ class ScrollCore {
         if scrollEvent.isTrackpad() {
             return Unmanaged.passUnretained(event)
         }
-        // 当事件来自远程桌面，且其发送的事件 isContinuous=1.0，此时跳过本地平滑
-        if ScrollUtils.shared.isRemoteSmoothedEvent(event) {
-            return Unmanaged.passUnretained(event)
-        }
         // 当鼠标输入, 根据需要执行翻转方向/平滑滚动
         // 获取事件目标
         let targetRunningApplication = ScrollUtils.shared.getRunningApplication(from: event)
+        // ToDesk 等远程控制链路无法稳定处理 Mos 合成的连续滚轮事件，只禁用平滑，保留翻转等原始事件处理。
+        let disableSmoothForRemoteControl = ScrollUtils.shared.shouldDisableSmoothForRemoteControl(
+            event,
+            targetRunningApplication: targetRunningApplication
+        )
+        let isRemoteSmoothedEvent = ScrollUtils.shared.isRemoteSmoothedEvent(event)
+        if isRemoteSmoothedEvent && !disableSmoothForRemoteControl {
+            return Unmanaged.passUnretained(event)
+        }
         // 获取列表中应用程序的列外设置信息
         ScrollCore.shared.application = ScrollUtils.shared.getTargetApplication(from: targetRunningApplication)
         // 平滑/翻转
@@ -116,6 +121,11 @@ class ScrollCore {
             let allowReverse = Options.shared.scroll.reverse
             enableReverseVertical = allowReverse && Options.shared.scroll.reverseVertical
             enableReverseHorizontal = allowReverse && Options.shared.scroll.reverseHorizontal
+        }
+        if disableSmoothForRemoteControl || isRemoteSmoothedEvent {
+            enableSmooth = false
+            enableSmoothVertical = false
+            enableSmoothHorizontal = false
         }
         // Launchpad 激活则强制屏蔽平滑
         if ScrollUtils.shared.getLaunchpadActivity(withRunningApplication: targetRunningApplication) {

--- a/Mos/ScrollCore/ScrollCore.swift
+++ b/Mos/ScrollCore/ScrollCore.swift
@@ -135,7 +135,8 @@ class ScrollCore {
             vertical: enableReverseVertical,
             horizontal: enableReverseHorizontal,
             bundlePath: targetRunningApplication?.bundleURL?.path,
-            bundleIdentifier: targetRunningApplication?.bundleIdentifier
+            bundleIdentifier: targetRunningApplication?.bundleIdentifier,
+            preserveRawDirection: useRawScrollForRemoteControl
         )
         enableReverseVertical = electronAdjustedReverse.vertical
         enableReverseHorizontal = electronAdjustedReverse.horizontal

--- a/Mos/ScrollCore/ScrollCore.swift
+++ b/Mos/ScrollCore/ScrollCore.swift
@@ -131,6 +131,14 @@ class ScrollCore {
             enableReverseVertical = false
             enableReverseHorizontal = false
         }
+        let electronAdjustedReverse = ScrollUtils.shared.adjustReverseForElectronTarget(
+            vertical: enableReverseVertical,
+            horizontal: enableReverseHorizontal,
+            bundlePath: targetRunningApplication?.bundleURL?.path,
+            bundleIdentifier: targetRunningApplication?.bundleIdentifier
+        )
+        enableReverseVertical = electronAdjustedReverse.vertical
+        enableReverseHorizontal = electronAdjustedReverse.horizontal
         // Launchpad 激活则强制屏蔽平滑
         if ScrollUtils.shared.getLaunchpadActivity(withRunningApplication: targetRunningApplication) {
             enableSmooth = false

--- a/Mos/ScrollCore/ScrollCore.swift
+++ b/Mos/ScrollCore/ScrollCore.swift
@@ -85,13 +85,13 @@ class ScrollCore {
         // 当鼠标输入, 根据需要执行翻转方向/平滑滚动
         // 获取事件目标
         let targetRunningApplication = ScrollUtils.shared.getRunningApplication(from: event)
-        // ToDesk 等远程控制链路无法稳定处理 Mos 合成的连续滚轮事件，只禁用平滑，保留翻转等原始事件处理。
-        let disableSmoothForRemoteControl = ScrollUtils.shared.shouldDisableSmoothForRemoteControl(
+        // ToDesk 等远程控制链路直接使用原始滚轮：关闭平滑和方向翻转。
+        let useRawScrollForRemoteControl = ScrollUtils.shared.shouldUseRawScrollForRemoteControl(
             event,
             targetRunningApplication: targetRunningApplication
         )
         let isRemoteSmoothedEvent = ScrollUtils.shared.isRemoteSmoothedEvent(event)
-        if isRemoteSmoothedEvent && !disableSmoothForRemoteControl {
+        if isRemoteSmoothedEvent && !useRawScrollForRemoteControl {
             return Unmanaged.passUnretained(event)
         }
         // 获取列表中应用程序的列外设置信息
@@ -122,10 +122,14 @@ class ScrollCore {
             enableReverseVertical = allowReverse && Options.shared.scroll.reverseVertical
             enableReverseHorizontal = allowReverse && Options.shared.scroll.reverseHorizontal
         }
-        if disableSmoothForRemoteControl || isRemoteSmoothedEvent {
+        if useRawScrollForRemoteControl || isRemoteSmoothedEvent {
             enableSmooth = false
             enableSmoothVertical = false
             enableSmoothHorizontal = false
+        }
+        if useRawScrollForRemoteControl {
+            enableReverseVertical = false
+            enableReverseHorizontal = false
         }
         // Launchpad 激活则强制屏蔽平滑
         if ScrollUtils.shared.getLaunchpadActivity(withRunningApplication: targetRunningApplication) {

--- a/Mos/ScrollCore/ScrollDispatchContext.swift
+++ b/Mos/ScrollCore/ScrollDispatchContext.swift
@@ -61,7 +61,8 @@ final class ScrollDispatchContext {
 #endif
             return false
         }
-        let pid = pid_t(event.getIntegerValueField(.eventTargetUnixProcessID))
+        let rawPID = pid_t(event.getIntegerValueField(.eventTargetUnixProcessID))
+        let pid = ScrollUtils.shared.resolveScrollTargetPID(rawPID)
         os_unfair_lock_lock(&lock)
         state.eventTemplate = template
         state.targetPID = pid

--- a/Mos/ScrollCore/ScrollUtils.swift
+++ b/Mos/ScrollCore/ScrollUtils.swift
@@ -121,33 +121,21 @@ class ScrollUtils {
     // 远程桌面事件检测缓存
     private var lastSourcePID: pid_t = 0
     private var lastSourceIsRemoteControl: Bool = false
+    private var lastSourceNeedsRawScrollPassthrough: Bool = false
 
     /// 检测事件来源是否为远程桌面应用
     func isFromRemoteApplication(_ event: CGEvent) -> Bool {
-        let sourcePID = pid_t(event.getIntegerValueField(.eventSourceUnixProcessID))
-        if sourcePID == 0 { return false }
-
-        if sourcePID != lastSourcePID {
-            lastSourcePID = sourcePID
-            lastSourceIsRemoteControl = false
-
-            if let app = NSRunningApplication(processIdentifier: sourcePID) {
-                // 检查可执行文件路径（系统守护进程）
-                if let path = app.executableURL?.path {
-                    for keyword in REMOTE_CONTROL_APPLICATION.executableKeywords {
-                        if path.contains(keyword) {
-                            lastSourceIsRemoteControl = true
-                            break
-                        }
-                    }
-                }
-                // 检查 Bundle Identifier（第三方应用）
-                if !lastSourceIsRemoteControl, let bundleId = app.bundleIdentifier {
-                    lastSourceIsRemoteControl = REMOTE_CONTROL_APPLICATION.bundleIdentifiers.contains(bundleId)
-                }
-            }
-        }
+        refreshRemoteSourceCacheIfNeeded(event)
         return lastSourceIsRemoteControl
+    }
+
+    /// ToDesk 等远程控制应用对 Mos 合成的连续滚轮事件兼容性差，需禁用平滑但保留方向翻转等原始事件处理。
+    func shouldDisableSmoothForRemoteControl(_ event: CGEvent, targetRunningApplication: NSRunningApplication?) -> Bool {
+        if needsRawScrollPassthrough(from: targetRunningApplication) {
+            return true
+        }
+        refreshRemoteSourceCacheIfNeeded(event)
+        return lastSourceNeedsRawScrollPassthrough
     }
 
     /// 检测事件是否来自已被平滑的远程源
@@ -157,6 +145,87 @@ class ScrollUtils {
         // 检查 isContinuous 字段判断是否为连续的
         let isContinuous = event.getDoubleValueField(.scrollWheelEventIsContinuous)
         return isContinuous == 1.0  // 1.0 表示主控端已平滑
+    }
+
+    func isKnownRemoteControlApplication(executablePath: String?, bundleIdentifier: String?) -> Bool {
+        if containsAnyKeyword(in: executablePath, keywords: REMOTE_CONTROL_APPLICATION.executableKeywords) {
+            return true
+        }
+        if let bundleIdentifier = bundleIdentifier,
+           REMOTE_CONTROL_APPLICATION.bundleIdentifiers.contains(bundleIdentifier) {
+            return true
+        }
+        return containsAnyKeyword(
+            in: bundleIdentifier,
+            keywords: REMOTE_CONTROL_APPLICATION.bundleIdentifierKeywords
+        )
+    }
+
+    func needsRawScrollPassthrough(executablePath: String?, bundleIdentifier: String?) -> Bool {
+        return containsAnyKeyword(
+            in: executablePath,
+            keywords: REMOTE_CONTROL_APPLICATION.rawScrollPassthroughExecutableKeywords
+        ) || containsAnyKeyword(
+            in: bundleIdentifier,
+            keywords: REMOTE_CONTROL_APPLICATION.rawScrollPassthroughBundleIdentifierKeywords
+        )
+    }
+
+    private func needsRawScrollPassthrough(from runningApplication: NSRunningApplication?) -> Bool {
+        guard let runningApplication = runningApplication else { return false }
+        return needsRawScrollPassthrough(
+            executablePath: runningApplication.executableURL?.path,
+            bundleIdentifier: runningApplication.bundleIdentifier
+        ) || needsRawScrollPassthrough(
+            executablePath: runningApplication.bundleURL?.path,
+            bundleIdentifier: runningApplication.bundleIdentifier
+        )
+    }
+
+    private func refreshRemoteSourceCacheIfNeeded(_ event: CGEvent) {
+        let sourcePID = pid_t(event.getIntegerValueField(.eventSourceUnixProcessID))
+        if sourcePID == 0 {
+            lastSourcePID = 0
+            lastSourceIsRemoteControl = false
+            lastSourceNeedsRawScrollPassthrough = false
+            return
+        }
+
+        if sourcePID != lastSourcePID {
+            lastSourcePID = sourcePID
+            lastSourceIsRemoteControl = false
+            lastSourceNeedsRawScrollPassthrough = false
+
+            guard let app = NSRunningApplication(processIdentifier: sourcePID) else { return }
+            let executablePath = app.executableURL?.path
+            let bundlePath = app.bundleURL?.path
+            let bundleIdentifier = app.bundleIdentifier
+
+            lastSourceIsRemoteControl = isKnownRemoteControlApplication(
+                executablePath: executablePath,
+                bundleIdentifier: bundleIdentifier
+            ) || isKnownRemoteControlApplication(
+                executablePath: bundlePath,
+                bundleIdentifier: bundleIdentifier
+            )
+            lastSourceNeedsRawScrollPassthrough = needsRawScrollPassthrough(
+                executablePath: executablePath,
+                bundleIdentifier: bundleIdentifier
+            ) || needsRawScrollPassthrough(
+                executablePath: bundlePath,
+                bundleIdentifier: bundleIdentifier
+            )
+        }
+    }
+
+    private func containsAnyKeyword(in value: String?, keywords: [String]) -> Bool {
+        guard let lowercasedValue = value?.lowercased() else { return false }
+        for keyword in keywords {
+            if lowercasedValue.contains(keyword.lowercased()) {
+                return true
+            }
+        }
+        return false
     }
 
     // MARK: - 滚动参数: 热键

--- a/Mos/ScrollCore/ScrollUtils.swift
+++ b/Mos/ScrollCore/ScrollUtils.swift
@@ -46,15 +46,39 @@ class ScrollUtils {
         lastEventTargetPID = currEventTargetPID
         // 更新当前 PID
         currEventTargetPID = pid
-        // 使用 PID 获取 BID
-        // 如果目标 PID 变化, 则重新获取一次窗口 BID
+        // 使用 PID 获取应用; Electron Helper 等嵌套进程回退到宿主 .app
         if lastEventTargetPID != currEventTargetPID {
-            cachedRunningApplication = NSRunningApplication.init(processIdentifier: pid)
+            let immediate = NSRunningApplication(processIdentifier: pid)
+            cachedRunningApplication = resolveHostApplication(immediate) ?? immediate
         }
         return cachedRunningApplication
     }
+
+    /// 将 Electron Helper / XPC 等嵌套进程解析为宿主应用, 供例外匹配和 CGEventPostToPid 使用
+    func resolveHostApplication(_ application: NSRunningApplication?) -> NSRunningApplication? {
+        guard let application = application else { return nil }
+        guard let hostPath = ScrollUtils.outermostAppBundlePath(from: application.bundleURL?.path)
+                ?? ScrollUtils.outermostAppBundlePath(from: application.executableURL?.path) else {
+            return application.activationPolicy == .regular ? application : nil
+        }
+        if application.bundleURL?.path == hostPath {
+            return application
+        }
+        if let host = NSWorkspace.shared.runningApplications.first(where: {
+            $0.activationPolicy == .regular && $0.bundleURL?.path == hostPath
+        }) {
+            return host
+        }
+        return application.activationPolicy == .regular ? application : nil
+    }
+
+    func resolveScrollTargetPID(_ pid: pid_t) -> pid_t {
+        guard pid > 1 else { return pid }
+        guard let application = NSRunningApplication(processIdentifier: pid) else { return pid }
+        return resolveHostApplication(application)?.processIdentifier ?? pid
+    }
     
-    // 判断目标是否为 Chrome
+    // 判断目标是否为 Chromium / Electron 家族 (Chrome 收尾帧对 Cursor / VS Code / Edge 同样必要)
     func isEventTargetingChrome(_ event: CGEvent?) -> Bool {
         guard let validEvent = event else {
             return false
@@ -62,10 +86,42 @@ class ScrollUtils {
         guard let targetRunningApplication = getRunningApplication(from: validEvent) else {
             return false
         }
-        if let targetBundleIdentifier = targetRunningApplication.bundleIdentifier, targetBundleIdentifier == "com.google.Chrome" {
+        return isChromiumFamilyApplication(
+            bundlePath: targetRunningApplication.bundleURL?.path,
+            bundleIdentifier: targetRunningApplication.bundleIdentifier
+        )
+    }
+
+    func isChromiumFamilyApplication(bundlePath: String?, bundleIdentifier: String?) -> Bool {
+        if let bundleIdentifier = bundleIdentifier?.lowercased() {
+            let prefixes = [
+                "com.google.chrome",
+                "com.microsoft.edgemac",
+                "com.brave.browser",
+                "com.operasoftware.opera",
+                "com.vivaldi.vivaldi",
+                "company.thebrowser.browser",
+                "com.microsoft.vscode",
+                "com.todesktop.",
+                "com.anysphere.",
+                "com.github.electron"
+            ]
+            if prefixes.contains(where: { bundleIdentifier == $0 || bundleIdentifier.hasPrefix($0) }) {
+                return true
+            }
+        }
+        guard let bundlePath = bundlePath else { return false }
+        let frameworks = (bundlePath as NSString).appendingPathComponent("Contents/Frameworks")
+        let electronFramework = (frameworks as NSString).appendingPathComponent("Electron Framework.framework")
+        if FileManager.default.fileExists(atPath: electronFramework) {
             return true
         }
-        return false
+        let chromeFramework = (frameworks as NSString).appendingPathComponent("Google Chrome Framework.framework")
+        if FileManager.default.fileExists(atPath: chromeFramework) {
+            return true
+        }
+        let loweredPath = bundlePath.lowercased()
+        return loweredPath.contains("electron framework") || loweredPath.contains("helper (renderer).app")
     }
     
     // 判断 LaunchPad 是否激活
@@ -108,13 +164,57 @@ class ScrollUtils {
     // 从 Applications 中取回符合传入的 key 的 Application 对象
     // Key 在 applications 初始化时指定于 Application 中
     func getTargetApplication(from runningApplication: NSRunningApplication?) -> Application? {
-        if let applicationByBundlePath = Options.shared.application.applications.get(by: runningApplication?.bundleURL?.path) {
+        return ScrollUtils.matchApplication(
+            bundlePath: runningApplication?.bundleURL?.path,
+            executablePath: runningApplication?.executableURL?.path,
+            in: Options.shared.application.applications
+        )
+    }
+
+    /// 例外列表按精确路径匹配; Electron Helper 再按最外层 .app 对齐到宿主条目
+    static func matchApplication(
+        bundlePath: String?,
+        executablePath: String?,
+        in applications: EnhanceArray<Application>
+    ) -> Application? {
+        if let applicationByBundlePath = applications.get(by: bundlePath) {
             return applicationByBundlePath
         }
-        if let applicationByExecutablePath = Options.shared.application.applications.get(by: runningApplication?.executableURL?.path) {
+        if let applicationByExecutablePath = applications.get(by: executablePath) {
             return applicationByExecutablePath
         }
+        guard let hostPath = outermostAppBundlePath(from: bundlePath)
+                ?? outermostAppBundlePath(from: executablePath) else {
+            return nil
+        }
+        if let applicationByHost = applications.get(by: hostPath) {
+            return applicationByHost
+        }
+        for index in 0..<applications.count {
+            guard let application = applications.get(by: index) else { continue }
+            if outermostAppBundlePath(from: application.path) == hostPath {
+                return application
+            }
+        }
         return nil
+    }
+
+    /// `/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Renderer).app` → `/Applications/Cursor.app`
+    static func outermostAppBundlePath(from path: String?) -> String? {
+        guard let path = path, !path.isEmpty else { return nil }
+        var url = URL(fileURLWithPath: path)
+        var lastApp: String?
+        while url.path != "/" && !url.path.isEmpty {
+            if url.pathExtension.lowercased() == "app" {
+                lastApp = url.path
+            }
+            let parent = url.deletingLastPathComponent()
+            if parent.path == url.path {
+                break
+            }
+            url = parent
+        }
+        return lastApp
     }
 
     // MARK: - 远程桌面事件检测

--- a/Mos/ScrollCore/ScrollUtils.swift
+++ b/Mos/ScrollCore/ScrollUtils.swift
@@ -129,8 +129,8 @@ class ScrollUtils {
         return lastSourceIsRemoteControl
     }
 
-    /// ToDesk 等远程控制应用对 Mos 合成的连续滚轮事件兼容性差，需禁用平滑但保留方向翻转等原始事件处理。
-    func shouldDisableSmoothForRemoteControl(_ event: CGEvent, targetRunningApplication: NSRunningApplication?) -> Bool {
+    /// ToDesk 等远程控制应用对 Mos 处理后的滚轮事件兼容性差，需关闭平滑和方向翻转。
+    func shouldUseRawScrollForRemoteControl(_ event: CGEvent, targetRunningApplication: NSRunningApplication?) -> Bool {
         if needsRawScrollPassthrough(from: targetRunningApplication) {
             return true
         }

--- a/Mos/ScrollCore/ScrollUtils.swift
+++ b/Mos/ScrollCore/ScrollUtils.swift
@@ -151,8 +151,13 @@ class ScrollUtils {
         vertical: Bool,
         horizontal: Bool,
         bundlePath: String?,
-        bundleIdentifier: String?
+        bundleIdentifier: String?,
+        preserveRawDirection: Bool = false
     ) -> (vertical: Bool, horizontal: Bool) {
+        // ToDesk 等远程链路已经要求保持原始方向, 不能再对 Cursor 做一次抵消翻转
+        if preserveRawDirection {
+            return (vertical, horizontal)
+        }
         guard isElectronFamilyApplication(bundlePath: bundlePath, bundleIdentifier: bundleIdentifier) else {
             return (vertical, horizontal)
         }

--- a/Mos/ScrollCore/ScrollUtils.swift
+++ b/Mos/ScrollCore/ScrollUtils.swift
@@ -123,6 +123,41 @@ class ScrollUtils {
         let loweredPath = bundlePath.lowercased()
         return loweredPath.contains("electron framework") || loweredPath.contains("helper (renderer).app")
     }
+
+    /// Cursor / VS Code 等 Electron 应用会把 isContinuous 像素事件当触控板再翻转一次
+    func isElectronFamilyApplication(bundlePath: String?, bundleIdentifier: String?) -> Bool {
+        if let bundleIdentifier = bundleIdentifier?.lowercased() {
+            let prefixes = [
+                "com.microsoft.vscode",
+                "com.todesktop.",
+                "com.anysphere.",
+                "com.github.electron"
+            ]
+            if prefixes.contains(where: { bundleIdentifier == $0 || bundleIdentifier.hasPrefix($0) }) {
+                return true
+            }
+        }
+        guard let bundlePath = bundlePath else { return false }
+        let frameworks = (bundlePath as NSString).appendingPathComponent("Contents/Frameworks")
+        let electronFramework = (frameworks as NSString).appendingPathComponent("Electron Framework.framework")
+        if FileManager.default.fileExists(atPath: electronFramework) {
+            return true
+        }
+        let loweredPath = bundlePath.lowercased()
+        return loweredPath.contains("electron framework") || loweredPath.contains("helper (renderer).app")
+    }
+
+    func adjustReverseForElectronTarget(
+        vertical: Bool,
+        horizontal: Bool,
+        bundlePath: String?,
+        bundleIdentifier: String?
+    ) -> (vertical: Bool, horizontal: Bool) {
+        guard isElectronFamilyApplication(bundlePath: bundlePath, bundleIdentifier: bundleIdentifier) else {
+            return (vertical, horizontal)
+        }
+        return (!vertical, !horizontal)
+    }
     
     // 判断 LaunchPad 是否激活
     var launchpadActiveCache = false

--- a/Mos/Utils/Constants.swift
+++ b/Mos/Utils/Constants.swift
@@ -70,6 +70,8 @@ struct REMOTE_CONTROL_APPLICATION {
         "screensharingd",          // macOS 屏幕共享守护进程
         "ScreensharingAgent",     // macOS 屏幕共享用户会话代理
         "ARDAgent",                // Apple Remote Desktop
+        "ToDesk",                  // ToDesk 远程控制相关进程
+        "todesk",                  // ToDesk helper/daemon 可能使用小写路径
     ]
     // Bundle Identifier（用于第三方应用）
     static let bundleIdentifiers = [
@@ -82,6 +84,18 @@ struct REMOTE_CONTROL_APPLICATION {
         "com.realvnc.vncviewer",
         "com.tigervnc.vncviewer",
         "com.netease.uuremote",  // UU 远程桌面
+    ]
+    // Bundle Identifier 关键字（用于 ToDesk 这类版本间可能变化的 ID）
+    static let bundleIdentifierKeywords = [
+        "todesk",
+    ]
+    // 这些远程控制应用无法稳定处理 Mos 合成的连续滚轮事件，需直接使用原始滚轮。
+    static let rawScrollPassthroughExecutableKeywords = [
+        "ToDesk",
+        "todesk",
+    ]
+    static let rawScrollPassthroughBundleIdentifierKeywords = [
+        "todesk",
     ]
 }
 

--- a/Mos/Utils/Constants.swift
+++ b/Mos/Utils/Constants.swift
@@ -89,7 +89,7 @@ struct REMOTE_CONTROL_APPLICATION {
     static let bundleIdentifierKeywords = [
         "todesk",
     ]
-    // 这些远程控制应用无法稳定处理 Mos 合成的连续滚轮事件，需直接使用原始滚轮。
+    // 这些远程控制应用无法稳定处理 Mos 修改后的滚轮事件，需关闭平滑和方向翻转。
     static let rawScrollPassthroughExecutableKeywords = [
         "ToDesk",
         "todesk",

--- a/Mos/Windows/PreferencesWindow/ApplicationView/PreferencesApplicationViewController.swift
+++ b/Mos/Windows/PreferencesWindow/ApplicationView/PreferencesApplicationViewController.swift
@@ -259,7 +259,7 @@ extension PreferencesApplicationViewController: NSMenuDelegate {
     }
     @objc func appendApplicationWithRunningApplication(_ sender: NSMenuItem!) {
         guard let runningApplication = sender.representedObject as? NSRunningApplication else { return }
-        guard let executablePath = runningApplication.executableURL?.path else { return }
-        appendApplicationWith(path: executablePath)
+        guard let path = runningApplication.bundleURL?.path ?? runningApplication.executableURL?.path else { return }
+        appendApplicationWith(path: path)
     }
 }

--- a/MosTests/ScrollEventTests.swift
+++ b/MosTests/ScrollEventTests.swift
@@ -29,6 +29,40 @@ final class ScrollEventTests: XCTestCase {
         return event
     }
 
+    // MARK: - 远程控制应用识别
+
+    func testRemoteControlApplicationDetectsToDeskExecutableKeyword() {
+        XCTAssertTrue(ScrollUtils.shared.isKnownRemoteControlApplication(
+            executablePath: "/Applications/ToDesk.app/Contents/MacOS/ToDesk",
+            bundleIdentifier: nil
+        ))
+    }
+
+    func testRemoteControlApplicationDetectsToDeskBundleIdentifierKeyword() {
+        XCTAssertTrue(ScrollUtils.shared.isKnownRemoteControlApplication(
+            executablePath: nil,
+            bundleIdentifier: "com.youqu.todesk"
+        ))
+    }
+
+    func testRemoteControlApplicationRequiresRawPassthroughForToDesk() {
+        XCTAssertTrue(ScrollUtils.shared.needsRawScrollPassthrough(
+            executablePath: "/Library/Application Support/ToDesk/ToDesk_Service",
+            bundleIdentifier: nil
+        ))
+    }
+
+    func testRemoteControlApplicationDoesNotRequireRawPassthroughForOtherRemoteApps() {
+        XCTAssertTrue(ScrollUtils.shared.isKnownRemoteControlApplication(
+            executablePath: nil,
+            bundleIdentifier: "com.teamviewer.TeamViewer"
+        ))
+        XCTAssertFalse(ScrollUtils.shared.needsRawScrollPassthrough(
+            executablePath: nil,
+            bundleIdentifier: "com.teamviewer.TeamViewer"
+        ))
+    }
+
     // MARK: - initEvent: 优先级 (scrollPt > scrollFixPt > scrollFix)
 
     func testInitEvent_prefersPtOverFixPt() throws {

--- a/MosTests/ScrollEventTests.swift
+++ b/MosTests/ScrollEventTests.swift
@@ -124,6 +124,45 @@ final class ScrollEventTests: XCTestCase {
         ))
     }
 
+    func testIsElectronFamily_detectsCursorButNotChrome() {
+        XCTAssertTrue(ScrollUtils.shared.isElectronFamilyApplication(
+            bundlePath: nil,
+            bundleIdentifier: "com.todesktop.230313mzl4w4u92"
+        ))
+        XCTAssertTrue(ScrollUtils.shared.isElectronFamilyApplication(
+            bundlePath: nil,
+            bundleIdentifier: "com.microsoft.VSCode"
+        ))
+        XCTAssertFalse(ScrollUtils.shared.isElectronFamilyApplication(
+            bundlePath: nil,
+            bundleIdentifier: "com.google.Chrome"
+        ))
+        XCTAssertFalse(ScrollUtils.shared.isElectronFamilyApplication(
+            bundlePath: "/Applications/Safari.app",
+            bundleIdentifier: "com.apple.Safari"
+        ))
+    }
+
+    func testAdjustReverseForElectron_xorsCursorAndLeavesSafari() {
+        let cursor = ScrollUtils.shared.adjustReverseForElectronTarget(
+            vertical: true,
+            horizontal: true,
+            bundlePath: nil,
+            bundleIdentifier: "com.todesktop.230313mzl4w4u92"
+        )
+        XCTAssertFalse(cursor.vertical)
+        XCTAssertFalse(cursor.horizontal)
+
+        let safari = ScrollUtils.shared.adjustReverseForElectronTarget(
+            vertical: true,
+            horizontal: false,
+            bundlePath: nil,
+            bundleIdentifier: "com.apple.Safari"
+        )
+        XCTAssertTrue(safari.vertical)
+        XCTAssertFalse(safari.horizontal)
+    }
+
     // MARK: - initEvent: 优先级 (scrollPt > scrollFixPt > scrollFix)
 
     func testInitEvent_prefersPtOverFixPt() throws {

--- a/MosTests/ScrollEventTests.swift
+++ b/MosTests/ScrollEventTests.swift
@@ -163,6 +163,18 @@ final class ScrollEventTests: XCTestCase {
         XCTAssertFalse(safari.horizontal)
     }
 
+    func testAdjustReverseForElectron_preservesRawDirectionDuringToDesk() {
+        let cursor = ScrollUtils.shared.adjustReverseForElectronTarget(
+            vertical: false,
+            horizontal: false,
+            bundlePath: nil,
+            bundleIdentifier: "com.todesktop.230313mzl4w4u92",
+            preserveRawDirection: true
+        )
+        XCTAssertFalse(cursor.vertical)
+        XCTAssertFalse(cursor.horizontal)
+    }
+
     // MARK: - initEvent: 优先级 (scrollPt > scrollFixPt > scrollFix)
 
     func testInitEvent_prefersPtOverFixPt() throws {

--- a/MosTests/ScrollEventTests.swift
+++ b/MosTests/ScrollEventTests.swift
@@ -63,6 +63,67 @@ final class ScrollEventTests: XCTestCase {
         ))
     }
 
+    // MARK: - Electron / Cursor 宿主匹配
+
+    func testOutermostAppBundlePath_resolvesCursorHelperToHostApp() {
+        let helper = "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Renderer).app"
+        XCTAssertEqual(
+            ScrollUtils.outermostAppBundlePath(from: helper),
+            "/Applications/Cursor.app"
+        )
+        XCTAssertEqual(
+            ScrollUtils.outermostAppBundlePath(from: "/Applications/Cursor.app/Contents/MacOS/Cursor"),
+            "/Applications/Cursor.app"
+        )
+        XCTAssertEqual(
+            ScrollUtils.outermostAppBundlePath(from: "/Applications/Cursor.app"),
+            "/Applications/Cursor.app"
+        )
+    }
+
+    func testMatchApplication_matchesCursorHelperToHostException() {
+        let applications = EnhanceArray<Application>(matchKey: "path")
+        applications.append(Application(path: "/Applications/Cursor.app/Contents/MacOS/Cursor"))
+
+        let matched = ScrollUtils.matchApplication(
+            bundlePath: "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Renderer).app",
+            executablePath: "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Renderer).app/Contents/MacOS/Cursor Helper (Renderer)",
+            in: applications
+        )
+        XCTAssertEqual(matched?.path, "/Applications/Cursor.app/Contents/MacOS/Cursor")
+    }
+
+    func testMatchApplication_matchesHostBundlePathException() {
+        let applications = EnhanceArray<Application>(matchKey: "path")
+        applications.append(Application(path: "/Applications/Cursor.app"))
+
+        let matched = ScrollUtils.matchApplication(
+            bundlePath: "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper.app",
+            executablePath: nil,
+            in: applications
+        )
+        XCTAssertEqual(matched?.path, "/Applications/Cursor.app")
+    }
+
+    func testIsChromiumFamily_detectsCursorAndVSCode() {
+        XCTAssertTrue(ScrollUtils.shared.isChromiumFamilyApplication(
+            bundlePath: nil,
+            bundleIdentifier: "com.todesktop.230313mzl4w4u92"
+        ))
+        XCTAssertTrue(ScrollUtils.shared.isChromiumFamilyApplication(
+            bundlePath: nil,
+            bundleIdentifier: "com.microsoft.VSCode"
+        ))
+        XCTAssertTrue(ScrollUtils.shared.isChromiumFamilyApplication(
+            bundlePath: "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Renderer).app",
+            bundleIdentifier: nil
+        ))
+        XCTAssertFalse(ScrollUtils.shared.isChromiumFamilyApplication(
+            bundlePath: "/Applications/Safari.app",
+            bundleIdentifier: "com.apple.Safari"
+        ))
+    }
+
     // MARK: - initEvent: 优先级 (scrollPt > scrollFixPt > scrollFix)
 
     func testInitEvent_prefersPtOverFixPt() throws {

--- a/scripts/generate-fork-appcast.py
+++ b/scripts/generate-fork-appcast.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Generate or merge the fork Sparkle appcast. Independent from Caldis/Mos."""
+
+import os
+import re
+import sys
+
+DEFAULT = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+    xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Mos Fork Updates</title>
+    <link>https://github.com/ZHOUSJ6/Mos</link>
+    <description>Independent updates for the ZHOUSJ6/Mos fork</description>
+    <language>en</language>
+  </channel>
+</rss>
+"""
+
+
+def extract_version(item: str) -> str:
+    match = re.search(r'sparkle:version="([^"]+)"', item)
+    return match.group(1) if match else ""
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: generate-fork-appcast.py <base_appcast_or_-> <bundle_version>")
+
+    base_path = sys.argv[1]
+    new_version = sys.argv[2]
+    new_item = os.environ.get("NEW_ITEM", "").strip()
+    if not new_item:
+        raise SystemExit("NEW_ITEM env var is required")
+
+    if base_path not in ("", "-") and os.path.exists(base_path):
+        text = open(base_path, "r", encoding="utf-8").read()
+    else:
+        text = DEFAULT
+
+    item_re = re.compile(r"<item\b.*?</item>", flags=re.S)
+    matches = list(item_re.finditer(text))
+    if matches:
+        prefix = text[: matches[0].start()]
+        suffix = text[matches[-1].end() :]
+        items = [match.group(0) for match in matches]
+    else:
+        insert_at = text.rfind("</channel>")
+        if insert_at == -1:
+            text = DEFAULT
+            insert_at = text.rfind("</channel>")
+        prefix = text[:insert_at]
+        suffix = text[insert_at:]
+        items = []
+
+    filtered = []
+    seen = set()
+    for item in items:
+        version = extract_version(item)
+        if version == new_version or version in seen:
+            continue
+        if version:
+            seen.add(version)
+        filtered.append(item)
+
+    all_items = [new_item] + filtered
+    sep = "\n\n    "
+    out = prefix + sep.join(item.strip() for item in all_items if item.strip()) + suffix
+    sys.stdout.write(out if out.endswith("\n") else out + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Detect ToDesk remote-control processes and bundle identifiers.
- Disable Mos smooth-scroll synthesis for ToDesk remote sessions so raw wheel events keep working.
- Preserve existing raw-event behavior such as reverse scrolling, and add coverage for ToDesk detection.

## Verification
- `DEVELOPER_DIR=\"/Applications/Xcode.app/Contents/Developer\" xcodebuild test -project \"Mos.xcodeproj\" -scheme \"Debug\" -configuration Debug -destination \"platform=macOS\" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=\"\"`
- 339 tests passed, 3 skipped, 0 failures.