### PR TITLE
[codex] Disable BLE standard button guard by default

### DIFF
--- a/Mos/Logi/Divert/LogiButtonDeliveryPolicy.swift
+++ b/Mos/Logi/Divert/LogiButtonDeliveryPolicy.swift
@@ -17,7 +17,7 @@ struct LogiButtonDeliveryPolicy {
 
     init(
         standardMouseButtonsUseNativeEvents: Bool,
-        standardButtonUndivertGuardEnabled: Bool = true,
+        standardButtonUndivertGuardEnabled: Bool = false,
         standardButtonUndivertGuardInterval: TimeInterval = 2.0
     ) {
         self.standardMouseButtonsUseNativeEvents = standardMouseButtonsUseNativeEvents
@@ -28,7 +28,7 @@ struct LogiButtonDeliveryPolicy {
     static var `default`: LogiButtonDeliveryPolicy {
         return LogiButtonDeliveryPolicy(
             standardMouseButtonsUseNativeEvents: boolDefaultingTrue(forKey: "LogiBLEStandardButtonsNativeFirst"),
-            standardButtonUndivertGuardEnabled: boolDefaultingTrue(forKey: "LogiBLEStandardUndivertGuardEnabled"),
+            standardButtonUndivertGuardEnabled: boolDefaultingFalse(forKey: "LogiBLEStandardUndivertGuardEnabled"),
             standardButtonUndivertGuardInterval: intervalDefaultingTwoSeconds(forKey: "LogiBLEStandardUndivertGuardInterval")
         )
     }
@@ -54,6 +54,11 @@ struct LogiButtonDeliveryPolicy {
 
     private static func boolDefaultingTrue(forKey key: String) -> Bool {
         guard UserDefaults.standard.object(forKey: key) != nil else { return true }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
+    private static func boolDefaultingFalse(forKey key: String) -> Bool {
+        guard UserDefaults.standard.object(forKey: key) != nil else { return false }
         return UserDefaults.standard.bool(forKey: key)
     }
 

--- a/MosTests/LogiButtonDeliveryModeTests.swift
+++ b/MosTests/LogiButtonDeliveryModeTests.swift
@@ -139,11 +139,27 @@ final class LogiButtonDeliveryModeTests: XCTestCase {
         XCTAssertEqual(LogiButtonDeliveryPolicy.default.standardButtonUndivertGuardInterval, 2)
     }
 
-    func testDefaultButtonDeliveryPolicyEnablesStandardUndivertGuard() {
+    func testDefaultButtonDeliveryPolicyDisablesStandardUndivertGuard() {
         let key = "LogiBLEStandardUndivertGuardEnabled"
         let defaults = UserDefaults.standard
         let original = defaults.object(forKey: key)
         defaults.removeObject(forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        XCTAssertFalse(LogiButtonDeliveryPolicy.default.standardButtonUndivertGuardEnabled)
+    }
+
+    func testUserDefaultCanEnableStandardUndivertGuard() {
+        let key = "LogiBLEStandardUndivertGuardEnabled"
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: key)
+        defaults.set(true, forKey: key)
         defer {
             if let original {
                 defaults.set(original, forKey: key)


### PR DESCRIPTION
## Summary

- Disable the BLE standard button undivert guard by default.
- Keep the existing user default override so `LogiBLEStandardUndivertGuardEnabled=true` can still opt back into the guard.
- Update `LogiButtonDeliveryModeTests` to cover both the new default and the explicit opt-in path.

## Root cause

The guard defaulted to enabled when the preference key was absent, so BLE standard button handling could still take the guarded undivert path even for users who had not opted into it. For the patch release, the safer default is disabled while preserving the existing preference key as an escape hatch.

## Validation

- `xcodebuild -scheme Debug -destination 'platform=macOS' test -only-testing:MosTests/LogiButtonDeliveryModeTests CODE_SIGN_IDENTITY='Apple Development' DEVELOPMENT_TEAM=N7Z52F27XK`
- `scripts/qa/lint-logi-boundary.sh`
- `xcodebuild -scheme Debug -destination 'platform=macOS' test CODE_SIGN_IDENTITY='Apple Development' DEVELOPMENT_TEAM=N7Z52F27XK`
- `git diff --check origin/master...HEAD`