### PR TITLE
fix(logi): skip keyboard interfaces so they can sleep (closes #948)

### DIFF
--- a/Mos/Logi/Core/LogiSessionManager.swift
+++ b/Mos/Logi/Core/LogiSessionManager.swift
@@ -109,17 +109,40 @@ internal class LogiSessionManager {
         let vendorId = IOHIDDeviceGetProperty(device, kIOHIDVendorIDKey as CFString) as? Int ?? 0
         let productId = IOHIDDeviceGetProperty(device, kIOHIDProductIDKey as CFString) as? Int ?? 0
         let productName = IOHIDDeviceGetProperty(device, kIOHIDProductKey as CFString) as? String ?? "Unknown"
+        let usagePage = IOHIDDeviceGetProperty(device, kIOHIDPrimaryUsagePageKey as CFString) as? Int ?? 0
+        let usage = IOHIDDeviceGetProperty(device, kIOHIDPrimaryUsageKey as CFString) as? Int ?? 0
 
         LogiDebugPanel.log("[LogitechHID] Device connected: \(productName) (VID: \(String(format: "0x%04X", vendorId)), PID: \(String(format: "0x%04X", productId)))")
 
         // 避免重复会话
         guard sessions[device] == nil else { return }
 
+        // 键盘接口跳过: Mos 对键盘没有 HID++ 用途, 一旦创建会话会在接口上注册
+        // input-report 回调, 使键盘无法进入休眠, 导致背光常亮 (issue #948)。
+        // 不创建 LogiDeviceSession 即可完全不触碰该 HID 接口。
+        guard Self.shouldAttachSession(usagePage: usagePage, usage: usage) else {
+            LogiDebugPanel.log("[LogitechHID] Skipping keyboard interface (keeps device awake): \(productName)")
+            return
+        }
+
         // 创建会话
         let session = LogiDeviceSession(hidDevice: device)
         sessions[device] = session
         session.setup()
         NotificationCenter.default.post(name: Self.sessionChangedNotification, object: nil)
+    }
+
+    /// 决定 Mos 是否应为某条 Logitech HID 接口创建会话。
+    ///
+    /// 键盘接口 (Generic Desktop `0x0001` / Keyboard `0x0006`) 永远不是 HID++ 候选
+    /// (`isHIDPPCandidate` 已为 false), 但 `setup()` 仍会在非候选接口上注册
+    /// input-report 回调。该回调对键盘毫无用处 (`handleInputReport` 只处理
+    /// HID++ 报文 `0x10/0x11`, 键盘不发), 却会让键盘 HID 端点保持活跃, 使其
+    /// 无法休眠、背光常亮。因此对键盘接口整条跳过, 不创建会话。见 issue #948。
+    static func shouldAttachSession(usagePage: Int, usage: Int) -> Bool {
+        // Generic Desktop (0x0001) Keyboard (0x0006)
+        if usagePage == 0x0001 && usage == 0x0006 { return false }
+        return true
     }
 
     private func deviceDisconnected(_ device: IOHIDDevice) {

--- a/MosTests/LogiTeardownTests.swift
+++ b/MosTests/LogiTeardownTests.swift
@@ -10,4 +10,37 @@ final class LogiTeardownTests: XCTestCase {
         // Smoke marker for the test plan; full coverage is in Tier 3a.
         XCTAssertTrue(true)
     }
+
+    // MARK: - Keyboard interface skip (issue #948)
+
+    /// A Logitech keyboard interface must NOT get a session attached. Attaching
+    /// one registers an input-report callback that keeps the keyboard's HID
+    /// endpoint active, so it never sleeps and its backlight stays on (#948).
+    /// `shouldAttachSession` gates session creation in `deviceConnected`.
+    func test_shouldAttachSession_skipsKeyboardInterface() {
+        // Generic Desktop (0x0001) Keyboard (0x0006) — e.g. MX Mechanical.
+        XCTAssertFalse(
+            LogiSessionManager.shouldAttachSession(usagePage: 0x0001, usage: 0x0006),
+            "Keyboard interfaces must be skipped so the device can sleep / dim its backlight"
+        )
+    }
+
+    func test_shouldAttachSession_attachesMouseAndHIDPPInterfaces() {
+        // Generic Desktop Mouse (0x0002) — BLE HID++ candidate.
+        XCTAssertTrue(LogiSessionManager.shouldAttachSession(usagePage: 0x0001, usage: 0x0002))
+        // Vendor-specific HID++ interfaces (USB receiver / Bolt / Unifying).
+        XCTAssertTrue(LogiSessionManager.shouldAttachSession(usagePage: 0xFF00, usage: 0x0000))
+        XCTAssertTrue(LogiSessionManager.shouldAttachSession(usagePage: 0xFF43, usage: 0x0000))
+        XCTAssertTrue(LogiSessionManager.shouldAttachSession(usagePage: 0xFFC0, usage: 0x0000))
+        // Consumer Control interface some Logi devices also expose.
+        XCTAssertTrue(LogiSessionManager.shouldAttachSession(usagePage: 0x000C, usage: 0x0001))
+    }
+
+    /// Regression guard: the skip must be keyboard-specific, not a blanket drop
+    /// of the whole Generic Desktop usage page (which would also drop BLE mice).
+    func test_shouldAttachSession_doesNotBlanketDropGenericDesktop() {
+        // Generic Desktop Pointer (0x0001) must still attach.
+        XCTAssertTrue(LogiSessionManager.shouldAttachSession(usagePage: 0x0001, usage: 0x0001),
+                      "Pointer (Generic Desktop) must still attach")
+    }
 }


### PR DESCRIPTION
## Problem

Fixes #948.

When Mos is running, a Logitech keyboard with a backlight (e.g. **MX Mechanical for Mac**) stays lit continuously instead of dimming/sleeping after idle.

## Root cause

`LogiSessionManager.start()` matches every Logitech device by vendor ID only (`0x046D`), so `deviceConnected()` creates a `LogiDeviceSession` and calls `setup()` for **every** interface — including the keyboard interface (`Generic Desktop 0x0001` / `Keyboard 0x0006`).

A keyboard interface is never an HID++ candidate (`isHIDPPCandidate` is `false`), but `setup()`'s non-candidate branch still registers an input-report callback on it:

```swift
guard isHIDPPCandidate else {
    LogiDebugPanel.log("\(tag) Skipping: not a HID++ candidate interface")
    setupInputReportCallback()   // <-- keeps the HID endpoint active
    return
}
```

That callback is useless for a keyboard — `handleInputReport` ignores everything except HID++ reports (`0x10`/`0x11`), which a keyboard never emits — but it keeps the keyboard's HID endpoint active, so the device never sleeps and the backlight stays on.

## Fix

Gate session creation in `deviceConnected` on `shouldAttachSession` and skip keyboard interfaces entirely, so Mos never touches that HID interface (no `LogiDeviceSession`, no input-report callback):

```swift
guard Self.shouldAttachSession(usagePage: usagePage, usage: usage) else {
    LogiDebugPanel.log("[LogitechHID] Skipping keyboard interface (keeps device awake): \(productName)")
    return
}
```

The skip is keyboard-specific (`0x0001` / `0x0006`) — it does not blanket-drop the Generic Desktop page, so BLE mice (`0x0001` / `0x0002`) and all HID++ interfaces (`0xFF00` / `0xFF43` / `0xFFC0`) keep attaching normally.

This aligns with the project's existing principle of not touching Logi devices unnecessarily — the BLE HID++ postmortem (`docs/plans/2026-05-03-logi-ble-hidpp-divert-postmortem.md`) removed keepalive/pulse for the same reason (avoid keeping devices busy).

## Verification

- `scripts/qa/lint-logi-boundary.sh` — passed
- `xcodebuild test -scheme Debug -destination 'platform=macOS'` — **488 tests, 0 failures** (3 skipped: real-device only)
- New regression tests in `LogiTeardownTests`:
  - keyboard interface (`0x0001`/`0x0006`) is skipped
  - mouse (`0x0002`), HID++ (`0xFF00`/`0xFF43`/`0xFFC0`) and consumer-control (`0x000C`) interfaces still attach
  - the skip is keyboard-specific (Generic Desktop Pointer `0x0001` still attaches)