### PR TITLE
fix(scroll): re-verify display link refresh rate after rebuild (#958)

### DIFF
--- a/Mos/ScrollCore/ScrollPoster.swift
+++ b/Mos/ScrollCore/ScrollPoster.swift
@@ -52,6 +52,15 @@ class ScrollPoster {
     private var lastCallbackTime: CFTimeInterval = 0.0
     private var lastRecreateAttempt: CFTimeInterval = 0.0
     private let recreateCooldown: CFTimeInterval = 3.0
+    // CVDisplayLink 刷新率自纠 (issue #958):
+    // 显示器唤醒/重连时会先短暂报告过渡刷新率 (如先 60Hz 再升 144Hz), 若重建正好落在这个窗口,
+    // 就会把 link 绑到偏低的刷新率, 使平滑滚动只按低帧率绘制 (卡顿), 而现有恢复机制识别不了.
+    // 对策: 每次建立 link 后延迟复查若干次, 发现 link 标称率明显低于显示器实际率就重建追平.
+    private var rateVerifyTimer: Timer?
+    private var rateVerifyAttemptsLeft = 0
+    private var isVerifying = false
+    private let rateVerifyDelays: [TimeInterval] = [2.0, 4.0, 8.0]
+    private let rateVerifyRatio = 0.7
     // 主线程访问, 无需锁
     var isAvailable: Bool { return poster != nil }
 }
@@ -190,6 +199,8 @@ extension ScrollPoster {
                 return kCVReturnSuccess
             }, nil)
             poster = validPoster
+            // 建立成功后安排刷新率复查; 复查内部触发的重建 (isVerifying) 不重置复查序列
+            if !isVerifying { scheduleRateVerify() }
         } else {
             poster = nil
             NSLog("ScrollPoster: CVDisplayLink creation failed (%d)", result)
@@ -293,6 +304,9 @@ extension ScrollPoster {
     func stopKeeper() {
         keeper?.invalidate()
         keeper = nil
+        rateVerifyTimer?.invalidate()
+        rateVerifyTimer = nil
+        rateVerifyAttemptsLeft = 0
     }
     private func healthCheck() {
         guard let validPoster = poster else {
@@ -309,6 +323,47 @@ extension ScrollPoster {
                 recreateDisplayLink()
             }
         }
+    }
+
+    // MARK: 刷新率自纠 (见属性处说明)
+    // 建立 link 后调用: 重置复查序列并安排第一次复查
+    private func scheduleRateVerify() {
+        rateVerifyAttemptsLeft = rateVerifyDelays.count
+        armNextRateVerify()
+    }
+    private func armNextRateVerify() {
+        rateVerifyTimer?.invalidate()
+        guard rateVerifyAttemptsLeft > 0 else { rateVerifyTimer = nil; return }
+        let delay = rateVerifyDelays[rateVerifyDelays.count - rateVerifyAttemptsLeft]
+        rateVerifyTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            self?.verifyRateAndFixIfNeeded()
+        }
+    }
+    // 复查: link 标称率明显低于显示器实际率 -> 重建追平 (幂等, 不受 recreateCooldown 限制)
+    private func verifyRateAndFixIfNeeded() {
+        rateVerifyAttemptsLeft -= 1
+        guard let current = poster else { rateVerifyTimer = nil; return }
+        let nominal = linkNominalHz(current)
+        let maxHz = maxActiveDisplayHz()
+        guard nominal > 1, maxHz > 1, nominal < maxHz * rateVerifyRatio else {
+            // 已追平显示器刷新率, 结束复查
+            rateVerifyTimer = nil
+            rateVerifyAttemptsLeft = 0
+            return
+        }
+        NSLog("ScrollPoster: display link rate %.0fHz below display %.0fHz, recreating", nominal, maxHz)
+        // 保持原运行状态: 若正在滚动 (running) 则重建后重新启动
+        let wasRunning = CVDisplayLinkIsRunning(current)
+        isVerifying = true
+        create()
+        isVerifying = false
+        if wasRunning, let refreshed = poster {
+            CVDisplayLinkStart(refreshed)
+        }
+        // 自纠说明显示器仍在过渡: 清除冷却, 让后续 screenChange 能及时用最终配置重建
+        lastRecreateAttempt = 0
+        // 这次重建可能仍落在过渡态, 继续后续复查直到追平或用尽次数
+        armNextRateVerify()
     }
 }
 
@@ -486,5 +541,29 @@ private extension ScrollPoster {
             phaseOverride: phaseOverride,
             fallbackToCurrentPhase: fallbackToCurrentPhase
         )
+    }
+}
+
+// MARK: - 显示器刷新率查询 (刷新率自纠使用)
+private extension ScrollPoster {
+    /// CVDisplayLink 当前绑定显示器的标称刷新率 (Hz); 无效返回 -1
+    func linkNominalHz(_ link: CVDisplayLink) -> Double {
+        let period = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(link)
+        // 无效/indefinite 周期时 timeValue 或 timeScale 为 0
+        guard period.timeValue != 0, period.timeScale != 0 else { return -1 }
+        let seconds = Double(period.timeValue) / Double(period.timeScale)
+        return seconds > 0 ? 1.0 / seconds : -1
+    }
+    /// 当前活跃显示器里最高刷新率 (Hz); 取不到返回 -1
+    func maxActiveDisplayHz() -> Double {
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return -1 }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return -1 }
+        var mx = -1.0
+        for id in ids.prefix(Int(count)) {
+            if let hz = CGDisplayCopyDisplayMode(id)?.refreshRate, hz > mx { mx = hz }
+        }
+        return mx
     }
 }


### PR DESCRIPTION
## Problem and cause analysis

Refer to https://github.com/Caldis/Mos/issues/958#issuecomment-4951437510

## Fix

After each `CVDisplayLink` creation, schedule a few delayed re-checks (+2s, +4s, +8s). If the link's nominal rate is well below the display's actual rate (< 70%), rebuild and clear the cooldown so any pending `screenChange` can also rebind.

- Only touches `ScrollPoster.swift` (+79 lines, no deletions)
- No changes to scroll/input event handling, cooldown logic, or other files
- Self-limiting: stops checking as soon as the rate matches, max 3 attempts

## Testing

Ran a debug build with rate-verify logging on my machine (MBP + 144Hz external display, macOS 26.5) for a week. The fix fired and self-corrected quite a few times, each time the link was rebound from 60Hz to 144Hz within ~2 seconds, with no manual restart needed. Prior to the fix, the same scenario required an app restart every time.

## Impact

Scroll smoothing behavior is unchanged — this only affects when and whether the `CVDisplayLink` gets recreated after a display transition. Worst case is an extra harmless recreation or two after a display wake.
