### PR TITLE
docs: replace placeholder SECURITY.md template with real policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,24 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Only the latest release receives security fixes. Please update to the
+[latest release](https://github.com/Caldis/Mos/releases/latest) before
+reporting a vulnerability.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Latest  | :white_check_mark: |
+| Older   | :x:                |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please **do not** open a public issue for security vulnerabilities.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Report privately via
+[GitHub Security Advisories](https://github.com/Caldis/Mos/security/advisories/new)
+for this repository. Include affected version(s), macOS version, and
+reproduction steps.
+
+We'll acknowledge reports as soon as possible and follow up once the issue
+has been triaged. If accepted, a fix will be released and credited in the
+release notes unless you request otherwise; if declined, we'll explain why.


### PR DESCRIPTION
## What changed

SECURITY.md was still GitHub's default scaffold: unfilled prose ("Use this section to tell people...") and a version table listing releases that don't exist (5.1.x, 5.0.x) while omitting the actual latest release line. This replaces both sections with real content:

- Supported Versions: states only the latest release gets security fixes, linked to `releases/latest` (currently 4.2.1).
- Reporting a Vulnerability: points reporters to GitHub Security Advisories instead of public issues, with expected response behavior.

## Why it matters

A security policy that's obviously an unedited template signals nobody reads security reports, and the fabricated version numbers are actively misleading (no 5.x release exists).

## Test plan

Docs-only change — checked Markdown renders correctly (table, emoji shortcodes, links), and verified both links resolve:
- `releases/latest` → 302s to `releases/tag/4.2.1`, the current release.
- `security/advisories/new` → correct URL pattern for GitHub's private vulnerability reporting.

## Note for maintainer

I can't confirm from outside whether "Private vulnerability reporting" is enabled in repo settings for this repository. If it isn't, the advisories link will 404 for reporters instead of showing the report form — worth a quick check/enable on your end.

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)