### PR TITLE
fix(buttons): preserve native side-button shortcut consumption

### DIFF
--- a/Mos/ButtonCore/ButtonCore.swift
+++ b/Mos/ButtonCore/ButtonCore.swift
@@ -35,6 +35,10 @@ class ButtonCore {
         return otherDown | otherUp | keyDown | keyUp
     }
 
+    // 在系统处理 Mission Control 等原生鼠标按钮快捷键之前拦截。
+    // 未被 Mos 绑定的事件继续向下传递，由系统按原有语义消费。
+    let dispatchEventTapLocation = CGEventTapLocation.cgSessionEventTap
+
     var primaryObservationEventMask: CGEventMask {
         return leftDown | leftUp | rightDown | rightUp
     }
@@ -90,7 +94,7 @@ class ButtonCore {
                 dispatchInterceptor = try Interceptor(
                     event: dispatchEventMask,
                     handleBy: buttonEventCallBack,
-                    listenOn: .cgAnnotatedSessionEventTap,
+                    listenOn: dispatchEventTapLocation,
                     placeAt: .tailAppendEventTap,
                     for: .defaultTap
                 )

--- a/MosTests/InputProcessorTests.swift
+++ b/MosTests/InputProcessorTests.swift
@@ -1080,6 +1080,13 @@ final class InputProcessorTests: XCTestCase {
         XCTAssertTrue(contains(.keyUp, in: core.dispatchEventMask))
     }
 
+    func testButtonCore_dispatchTapRunsBeforeNativeMouseButtonShortcuts() {
+        XCTAssertEqual(
+            ButtonCore.shared.dispatchEventTapLocation.rawValue,
+            CGEventTapLocation.cgSessionEventTap.rawValue
+        )
+    }
+
     func testButtonCore_primaryObservationMask_includesPrimaryMouseButtons() {
         let core = ButtonCore.shared
 


### PR DESCRIPTION
## Summary

- Move the active `ButtonCore` dispatch tap from `cgAnnotatedSessionEventTap` to `cgSessionEventTap`.
- Keep the passive primary-button observer unchanged.
- Add regression coverage for the dispatch tap location.

## Root cause

The affected side button is mapped by macOS itself to Mission Control. With Mos intercepting at the annotated-session stage, an unbound button event could continue to the target application after the native shortcut had already fired, producing both Mission Control and back navigation.

Intercepting at the session stage preserves both paths: Mos-bound events can still be consumed before native handling, while unbound events continue through the normal macOS shortcut processing and are consumed by the system as expected. The previous button-number mutation did not address this path because the event was not consumed by a Mos binding.

## Validation

- `InputProcessorTests`: 50 tests passed, 0 failures.
- Manual validation with Attack Shark mouse, macOS 26.5.2, and the native side-button-to-Mission-Control mapping: Mission Control opens and the active browser no longer navigates back.
- `git diff --check` passed.

Fixes #907