### PR TITLE
fix(interceptor): invalidate event tap CFMachPort on deinit

### DIFF
--- a/Mos.xcodeproj/project.pbxproj
+++ b/Mos.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		D1A2B3C4E5F6A7B8C9D01402 /* MosTests/LogiButtonDeliveryModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01403 /* MosTests/LogiButtonDeliveryModeTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01500 /* MosTests/LogiHapticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01501 /* MosTests/LogiHapticTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01600 /* MosTests/InterceptorAutoRestartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01601 /* MosTests/InterceptorAutoRestartTests.swift */; };
+		D1A2B3C4E5F6A7B8C9D0AA00 /* MosTests/InterceptorTapLeakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D0AA01 /* MosTests/InterceptorTapLeakTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01700 /* MosTests/LogiScrollForceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01701 /* MosTests/LogiScrollForceTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01800 /* MosTests/LogiForceSensingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01801 /* MosTests/LogiForceSensingTests.swift */; };
 		D3A1B2C3D4E5F60718293A50 /* MosTests/ScrollActionPortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C3D4E5F60718293A51 /* MosTests/ScrollActionPortTests.swift */; };
@@ -109,6 +110,7 @@
 		D1A2B3C4E5F6A7B8C9D01403 /* MosTests/LogiButtonDeliveryModeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiButtonDeliveryModeTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01501 /* MosTests/LogiHapticTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiHapticTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01601 /* MosTests/InterceptorAutoRestartTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/InterceptorAutoRestartTests.swift; sourceTree = SOURCE_ROOT; };
+		D1A2B3C4E5F6A7B8C9D0AA01 /* MosTests/InterceptorTapLeakTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/InterceptorTapLeakTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01701 /* MosTests/LogiScrollForceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiScrollForceTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01801 /* MosTests/LogiForceSensingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiForceSensingTests.swift; sourceTree = SOURCE_ROOT; };
 		D3A1B2C3D4E5F60718293A51 /* MosTests/ScrollActionPortTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollActionPortTests.swift; sourceTree = SOURCE_ROOT; };
@@ -192,6 +194,7 @@
 				D1A2B3C4E5F6A7B8C9D01701 /* MosTests/LogiScrollForceTests.swift */,
 				D1A2B3C4E5F6A7B8C9D01801 /* MosTests/LogiForceSensingTests.swift */,
 				D1A2B3C4E5F6A7B8C9D01601 /* MosTests/InterceptorAutoRestartTests.swift */,
+				D1A2B3C4E5F6A7B8C9D0AA01 /* MosTests/InterceptorTapLeakTests.swift */,
 				D1A2B3C4E5F6A7B8C9D01403 /* MosTests/LogiButtonDeliveryModeTests.swift */,
 				D1A2B3C4E5F6A7B8C9D0120E /* LogiTestDoubles */,
 				B3D4E5F6A7B8C9D0E1F40101 /* MosTests/MouseInteractionSessionControllerTests.swift */,
@@ -408,6 +411,7 @@
 				D1A2B3C4E5F6A7B8C9D01700 /* MosTests/LogiScrollForceTests.swift in Sources */,
 				D1A2B3C4E5F6A7B8C9D01800 /* MosTests/LogiForceSensingTests.swift in Sources */,
 				D1A2B3C4E5F6A7B8C9D01600 /* MosTests/InterceptorAutoRestartTests.swift in Sources */,
+				D1A2B3C4E5F6A7B8C9D0AA00 /* MosTests/InterceptorTapLeakTests.swift in Sources */,
 				D1A2B3C4E5F6A7B8C9D01402 /* MosTests/LogiButtonDeliveryModeTests.swift in Sources */,
 				B3D4E5F6A7B8C9D0E1F40100 /* MosTests/MouseInteractionSessionControllerTests.swift in Sources */,
 				FE05F3803FB8885AAC70ADC5 /* MosTests/ScrollCoreHotkeyTests.swift in Sources */,

--- a/Mos/Utils/Interceptor.swift
+++ b/Mos/Utils/Interceptor.swift
@@ -56,6 +56,11 @@ class Interceptor {
         // 清理 event tap
         if let tap = _eventTapRef {
             CGEvent.tapEnable(tap: tap, enable: false)
+            // CoreGraphics 内部持有该 CFMachPort 的引用, 仅释放引用不会销毁它; 不调用
+            // CFMachPortInvalidate 的话, WindowServer 会保留这个 (已禁用的) tap 注册直到
+            // 进程退出。ScrollCore/ButtonCore 每次休眠唤醒都重建 Interceptor, 累积的僵尸
+            // 注册会拖慢全系统输入 (#970)。
+            CFMachPortInvalidate(tap)
             _eventTapRef = nil
         }
         // 清理 run loop source

--- a/MosTests/InterceptorTapLeakTests.swift
+++ b/MosTests/InterceptorTapLeakTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Mos_Debug
+
+/// Interceptor 销毁后 WindowServer 侧 event tap 注册的回归测试.
+/// 场景背景: CGEventTapCreate 返回的 CFMachPort 被 CoreGraphics 内部持有引用, 仅释放
+/// 引用不会销毁它; deinit 若不调用 CFMachPortInvalidate, WindowServer 会保留 (已禁用的)
+/// tap 注册直到进程退出。ScrollCore/ButtonCore 每次休眠唤醒都会重建 Interceptor, 泄漏
+/// 会累积成上千僵尸注册, 拖慢全系统输入 (#970)。
+final class InterceptorTapLeakTests: XCTestCase {
+
+    /// 当前进程在 WindowServer tap 表中持有的注册数
+    private func ownTapCount() -> Int {
+        var count: UInt32 = 0
+        CGGetEventTapList(0, nil, &count)
+        var taps = [CGEventTapInformation](repeating: CGEventTapInformation(), count: Int(count) + 16)
+        var actual: UInt32 = 0
+        CGGetEventTapList(UInt32(taps.count), &taps, &actual)
+        let pid = getpid()
+        return taps.prefix(Int(actual)).filter { $0.tappingProcess == pid }.count
+    }
+
+    func testDeinitReleasesWindowServerRegistration() throws {
+        let baseline = ownTapCount()
+
+        // init 在 start() 的辅助功能权限检查之前就已创建 tap, 所以即使 init 抛错
+        // (无权限环境, 例如 CI), tap 也已在 WindowServer 注册过、并已随抛错时的 deinit
+        // 销毁 —— 两条路径都必须回到基线, 泄漏断言对两者同样有效。
+        let callback: CGEventTapCallBack = { _, _, event, _ in Unmanaged.passUnretained(event) }
+        var interceptor: Interceptor?
+        do {
+            interceptor = try Interceptor(
+                event: CGEventMask(1 << CGEventType.scrollWheel.rawValue),
+                handleBy: callback,
+                listenOn: .cgAnnotatedSessionEventTap,
+                placeAt: .tailAppendEventTap,
+                for: .listenOnly
+            )
+        } catch Interceptor.InterceptorError.eventTapCreationFailed {
+            // 连 tap 都创建不了 (受限沙箱等), 无法验证泄漏, 跳过而非误报
+            throw XCTSkip("无法创建 event tap")
+        } catch {
+            // 权限检查抛错: tap 曾被创建, deinit 已运行 —— 直接验证没有残留注册
+            XCTAssertEqual(baseline, ownTapCount())
+            return
+        }
+
+        XCTAssertNotNil(interceptor)
+        XCTAssertEqual(baseline + 1, ownTapCount())
+
+        interceptor = nil
+        XCTAssertEqual(baseline, ownTapCount())
+    }
+}

--- a/MosTests/InterceptorTapLeakTests.swift
+++ b/MosTests/InterceptorTapLeakTests.swift
@@ -8,19 +8,23 @@ import XCTest
 /// 会累积成上千僵尸注册, 拖慢全系统输入 (#970)。
 final class InterceptorTapLeakTests: XCTestCase {
 
-    /// 当前进程在 WindowServer tap 表中持有的注册数
-    private func ownTapCount() -> Int {
+    /// 当前进程在 WindowServer tap 表中持有的注册数; CGGetEventTapList 调用失败时返回 nil
+    /// (由调用方决定跳过或失败), 避免把查询失败误读成 0 个注册。
+    private func ownTapCount() -> Int? {
         var count: UInt32 = 0
-        CGGetEventTapList(0, nil, &count)
+        guard CGGetEventTapList(0, nil, &count) == .success else { return nil }
         var taps = [CGEventTapInformation](repeating: CGEventTapInformation(), count: Int(count) + 16)
         var actual: UInt32 = 0
-        CGGetEventTapList(UInt32(taps.count), &taps, &actual)
+        guard CGGetEventTapList(UInt32(taps.count), &taps, &actual) == .success else { return nil }
         let pid = getpid()
         return taps.prefix(Int(actual)).filter { $0.tappingProcess == pid }.count
     }
 
     func testDeinitReleasesWindowServerRegistration() throws {
-        let baseline = ownTapCount()
+        // 查询本身失败 (受限环境) 时无法验证, 跳过; 之后的查询失败则按断言失败处理
+        guard let baseline = ownTapCount() else {
+            throw XCTSkip("CGGetEventTapList 调用失败")
+        }
 
         // init 在 start() 的辅助功能权限检查之前就已创建 tap, 所以即使 init 抛错
         // (无权限环境, 例如 CI), tap 也已在 WindowServer 注册过、并已随抛错时的 deinit


### PR DESCRIPTION
This PR fixes a resource leak in `Interceptor` that seems to be the cause of #970: after the Mac has been asleep (or users switch accounts) repeatedly, the whole system's input becomes laggy while Mos itself shows ~0% CPU, and killing Mos restores fluidity.

The same bug class was recently root-caused, fixed, and confirmed in Karabiner-Elements ([pqrs-org/Karabiner-Elements#4505](https://github.com/pqrs-org/Karabiner-Elements/pull/4505) — includes a video of the symptom) and in Easydict ([tisfeng/Easydict#1170](https://github.com/tisfeng/Easydict/issues/1170), maintainer-confirmed). Scripts to reproduce and observe the leak are at the bottom.

Fixes #970. Plausibly also related to the intermittent post-idle scroll delays in #627.

This fix and analysis were prepared with AI assistance (Claude), per CONTRIBUTING.md: I understand every changed line (except for the Chinese comments 😅), and all measurements/repro outputs below are from a real machine (macOS 26.5, Apple Silicon), reviewed by a human.

## Motivation / mechanism

CoreGraphics holds internal references to the `CFMachPort` returned by `CGEventTapCreate` (observed retain count 4 immediately after creation), so releasing the client reference never deallocates it — and **the WindowServer keeps the (disabled) event-tap registration until the process exits**. The only correct disposal is an explicit `CFMachPortInvalidate`.

`Interceptor.deinit` currently does `CGEvent.tapEnable(false)` + `CFRunLoopRemoveSource` + nils the references — without the invalidate. Every deallocated `Interceptor` therefore leaks one zombie registration in the WindowServer's global tap table:

- `ScrollCore.disable()` + `ButtonCore.disable()` destroy **5 interceptors** on every `willSleepNotification` / `sessionDidResignActiveNotification`, recreated on wake — so each sleep/wake or fast-user-switch cycle leaks 5 registrations.
- Additional smaller sources: `KeyRecorder` (one per shortcut-recording session), the monitor window's interceptors, and runtime Accessibility-permission loss/regain cycles.

Observed on my machine (Mos 4.2.x, macOS 26.5, uptime 6.5 days): **105–110 stale registrations (~16/day)**. WindowServer's per-event tap-table processing scales with table size; once the table is large (in my case other leaking apps contributed too), the whole Mac's input turns visibly laggy while the responsible apps sit at 0% CPU — exactly the profile in #970 (WindowServer at 77–100% of a core during window drags, Mos at ~0%). Killing the process reaps all its entries instantly, which is why "kill Mos in Activity Monitor" fixes it and a fresh Mos is fine again.

Standalone verification (no Mos involved): creating 1,000 disabled listen-only taps with the script below makes input noticeably sluggish within seconds; releasing them (or process exit) restores it. Repeating an Interceptor-style teardown (release without invalidate) in a loop grows the owning process's tap-table entry count by exactly 1 per cycle; with `CFMachPortInvalidate` the entry is reaped immediately.

## What changed

- `Interceptor.deinit`: `CFMachPortInvalidate(tap)` before dropping the reference (one line + comment). No behavior change on any input path — the tap is already disabled at this point; this only releases the WindowServer-side registration that was previously leaked.
- Regression test `MosTests/InterceptorTapLeakTests.swift`: creates an `Interceptor` and asserts the process's own `CGGetEventTapList` registration count returns to baseline once it's gone. Because `init` creates the tap *before* the `AXIsProcessTrusted` guard in `start()` can throw, the permission-denied path (e.g. CI) creates-and-leaks too — so the test covers it with the same assertion instead of skipping; it only skips when tap creation itself fails.

## Validation

- `xcodebuild -scheme Debug -configuration Debug build` succeeds with the change, and the regression test was executed both ways (ad-hoc-signed locally, since the project pins the maintainer's signing team): **fails on the unfixed `Interceptor` (`XCTAssertEqual failed: ("0") is not equal to ("1")` — one residual registration) and passes with the fix.**
- Mechanism verified standalone as described above; the deinit path with the fix is structurally identical to the verified clean variant.
- Suggested check on a fixed build: run `taplist.swift` (below) before/after a few sleep/wake cycles — Mos's disabled-entry count should stay at 0 instead of growing by 5 per cycle.

## Compatibility / risk

Disposal-only change at object teardown; no event-handling, permission, or configuration behavior is touched. `pause()`/`start()` cycles reuse the live tap and are unaffected (invalidate happens only in `deinit`).

## Scripts

<details>
<summary><code>taplist.swift</code> — enumerate the WindowServer tap table grouped by owning process (<code>swift taplist.swift</code>)</summary>

```swift
import AppKit
import CoreGraphics
import Darwin

var count: UInt32 = 0
CGGetEventTapList(0, nil, &count)
var taps = [CGEventTapInformation](repeating: CGEventTapInformation(), count: Int(count) + 16)
var actual: UInt32 = 0
let err = CGGetEventTapList(UInt32(taps.count), &taps, &actual)
taps = Array(taps.prefix(Int(actual)))

func processName(_ pid: pid_t) -> String {
    if let app = NSRunningApplication(processIdentifier: pid) { return app.localizedName ?? "pid\(pid)" }
    var buffer = [CChar](repeating: 0, count: 4096)
    if proc_name(pid, &buffer, UInt32(buffer.count)) > 0 { return String(cString: buffer) }
    // proc_name fails with EPERM for other users' (e.g. root) processes; sysctl works cross-user.
    var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
    var info = kinfo_proc()
    var size = MemoryLayout<kinfo_proc>.stride
    if sysctl(&mib, 4, &info, &size, nil, 0) == 0, size > 0, info.kp_proc.p_pid == pid {
        let name = withUnsafeBytes(of: info.kp_proc.p_comm) { raw in
            String(decoding: raw.prefix(while: { $0 != 0 }), as: UTF8.self)
        }
        if !name.isEmpty { return "\(name) (pid \(pid))" }
    }
    return "pid\(pid)(gone)"
}

print("total taps: \(actual) (err=\(err.rawValue))")
var byProcess: [pid_t: (name: String, enabled: Int, disabled: Int)] = [:]
for t in taps {
    var entry = byProcess[t.tappingProcess] ?? (processName(t.tappingProcess), 0, 0)
    if t.enabled { entry.enabled += 1 } else { entry.disabled += 1 }
    byProcess[t.tappingProcess] = entry
}
for (pid, entry) in byProcess.sorted(by: { ($0.value.enabled + $0.value.disabled) > ($1.value.enabled + $1.value.disabled) }) {
    print(String(format: "pid %6d  %-40@  enabled=%d disabled=%d", pid, entry.name as NSString, entry.enabled, entry.disabled))
}
```

Observed on my machine (before restarting the two leaking apps):

```
total taps: 1038
pid  12213  Karabiner-Core-Service  enabled=1 disabled=953
pid  11799  Mos                     enabled=5 disabled=55
...
```

</details>

<details>
<summary><code>bloatgen.swift</code> — demonstrate that stale disabled registrations alone degrade input (<code>swift bloatgen.swift 1000 30</code>)</summary>

```swift
import AppKit
import CoreGraphics

// Creates N disabled listen-only taps (the exact server-side state the leak
// produces), holds them so system impact can be observed, then invalidates
// everything and exits. Process death reaps all entries — cannot leave residue.
// Usage: swift bloatgen.swift [count] [holdSeconds]

let count = CommandLine.arguments.count > 1 ? (Int(CommandLine.arguments[1]) ?? 1000) : 1000
let holdSeconds = CommandLine.arguments.count > 2 ? (Int(CommandLine.arguments[2]) ?? 30) : 30

func totalTaps() -> Int {
    var count: UInt32 = 0
    CGGetEventTapList(0, nil, &count)
    return Int(count)
}

let callback: CGEventTapCallBack = { _, _, event, _ in Unmanaged.passUnretained(event) }
let mask: CGEventMask =
    (1 << CGEventType.mouseMoved.rawValue)
    | (1 << CGEventType.leftMouseDown.rawValue)
    | (1 << CGEventType.leftMouseUp.rawValue)
    | (1 << CGEventType.rightMouseDown.rawValue)
    | (1 << CGEventType.rightMouseUp.rawValue)
    | (1 << CGEventType.leftMouseDragged.rawValue)
    | (1 << CGEventType.scrollWheel.rawValue)

setvbuf(stdout, nil, _IOLBF, 0)
let baseline = totalTaps()
print("baseline tap table: \(baseline) entries")

var held: [CFMachPort] = []
held.reserveCapacity(count)
for i in 0..<count {
    guard let tap = CGEvent.tapCreate(
        tap: .cghidEventTap, place: .tailAppendEventTap, options: .listenOnly,
        eventsOfInterest: mask, callback: callback, userInfo: nil)
    else {
        print("tapCreate FAILED at #\(i + 1) — holding the \(held.count) created so far")
        break
    }
    CGEvent.tapEnable(tap: tap, enable: false)
    held.append(tap)
}
print("created \(held.count) disabled taps — table now: \(totalTaps())")
NSSound.beep()
print("HOLDING for \(holdSeconds)s — wiggle the trackpad / drag windows and observe…")
for remaining in stride(from: holdSeconds, to: 0, by: -5) {
    print("  …\(remaining)s left (table: \(totalTaps()))")
    Thread.sleep(forTimeInterval: min(5, Double(remaining)))
}
for tap in held { CFMachPortInvalidate(tap) }
held.removeAll()
NSSound.beep()
print("released — table back to: \(totalTaps()) entries (baseline was \(baseline))")
```

</details>
