### PR TITLE
fix: prevent stuck left mouse button in After Effects

### DIFF
--- a/Mos/ButtonCore/ButtonCore.swift
+++ b/Mos/ButtonCore/ButtonCore.swift
@@ -19,29 +19,22 @@ class ButtonCore {
     
     // 拦截层
     var dispatchInterceptor: Interceptor?
-    var primaryObservationInterceptor: Interceptor?
-
     // 组合的按钮事件掩码
-    let leftDown = CGEventMask(1 << CGEventType.leftMouseDown.rawValue)
-    let leftUp = CGEventMask(1 << CGEventType.leftMouseUp.rawValue)
-    let rightDown = CGEventMask(1 << CGEventType.rightMouseDown.rawValue)
-    let rightUp = CGEventMask(1 << CGEventType.rightMouseUp.rawValue)
     let otherDown = CGEventMask(1 << CGEventType.otherMouseDown.rawValue)
     let keyDown = CGEventMask(1 << CGEventType.keyDown.rawValue)
     let flagsChanged = CGEventMask(1 << CGEventType.flagsChanged.rawValue)
     let otherUp = CGEventMask(1 << CGEventType.otherMouseUp.rawValue)
     let keyUp = CGEventMask(1 << CGEventType.keyUp.rawValue)
     var dispatchEventMask: CGEventMask {
+        // Primary mouse buttons are intentionally excluded. Mos does not allow
+        // recording an unmodified primary click, and installing a global tap for
+        // those events can disturb applications that manage their own drag state.
         return otherDown | otherUp | keyDown | keyUp
     }
 
     // 在系统处理 Mission Control 等原生鼠标按钮快捷键之前拦截。
     // 未被 Mos 绑定的事件继续向下传递，由系统按原有语义消费。
     let dispatchEventTapLocation = CGEventTapLocation.cgSessionEventTap
-
-    var primaryObservationEventMask: CGEventMask {
-        return leftDown | leftUp | rightDown | rightUp
-    }
 
     // MARK: - 按钮事件处理
     let buttonEventCallBack: CGEventTapCallBack = { (proxy, type, event, refcon) in
@@ -75,16 +68,6 @@ class ButtonCore {
         }
     }
 
-    let primaryMouseObservationCallBack: CGEventTapCallBack = { (_, type, event, _) in
-        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            return Unmanaged.passUnretained(event)
-        }
-        if event.getIntegerValueField(.eventSourceUserData) == MosEventMarker.syntheticCustom {
-            return Unmanaged.passUnretained(event)
-        }
-        return Unmanaged.passUnretained(event)
-    }
-    
     // MARK: - 启用和禁用
     
     // 启用按钮监控
@@ -101,19 +84,10 @@ class ButtonCore {
                 dispatchInterceptor?.onRestart = {
                     InputProcessor.shared.clearActiveBindings()
                 }
-                primaryObservationInterceptor = try Interceptor(
-                    event: primaryObservationEventMask,
-                    handleBy: primaryMouseObservationCallBack,
-                    listenOn: .cgAnnotatedSessionEventTap,
-                    placeAt: .tailAppendEventTap,
-                    for: .listenOnly
-                )
                 isActive = true
             } catch {
                 dispatchInterceptor?.stop()
-                primaryObservationInterceptor?.stop()
                 dispatchInterceptor = nil
-                primaryObservationInterceptor = nil
                 NSLog("ButtonCore: Failed to create interceptor: \(error)")
             }
         }
@@ -124,9 +98,7 @@ class ButtonCore {
         if isActive {
             NSLog("ButtonCore disabled")
             dispatchInterceptor?.stop()
-            primaryObservationInterceptor?.stop()
             dispatchInterceptor = nil
-            primaryObservationInterceptor = nil
             InputProcessor.shared.clearActiveBindings()
             isActive = false
         }

--- a/MosTests/InputProcessorTests.swift
+++ b/MosTests/InputProcessorTests.swift
@@ -889,32 +889,6 @@ final class InputProcessorTests: XCTestCase {
         XCTAssertTrue(event.flags.contains(.maskShift))
     }
 
-    func testButtonCore_passthroughRealLeftMouseEvent_doesNotApplyVirtualModifierFlags() {
-        let modifierTrigger = RecordedEvent(type: .mouse, code: 6, modifiers: 0, displayComponents: ["🖱7"], deviceFilter: nil)
-        let modifierBinding = ButtonBinding(triggerEvent: modifierTrigger, systemShortcutName: "custom::56:0", isEnabled: true)
-        Options.shared.buttons.binding = [modifierBinding]
-        ButtonUtils.shared.invalidateCache()
-
-        let modifierDown = InputEvent(type: .mouse, code: 6, modifiers: .init(rawValue: 0),
-                                      phase: .down, source: .hidPP, device: nil)
-        XCTAssertEqual(InputProcessor.shared.process(modifierDown), .consumed)
-        XCTAssertEqual(InputProcessor.shared.activeModifierFlags, CGEventFlags.maskShift.rawValue)
-
-        let event = CGEvent(
-            mouseEventSource: nil,
-            mouseType: .leftMouseDown,
-            mouseCursorPosition: CGPoint(x: 16, y: 24),
-            mouseButton: .left
-        )!
-        event.flags = CGEventFlags(rawValue: 0)
-
-        let proxy = CGEventTapProxy(bitPattern: 1)!
-        let output = ButtonCore.shared.primaryMouseObservationCallBack(proxy, .leftMouseDown, event, nil)
-
-        XCTAssertNotNil(output)
-        XCTAssertFalse(event.flags.contains(.maskShift))
-    }
-
     func testCGEventExtensions_otherMouseDraggedIsRecognizedForDiagnostics() {
         let event = CGEvent(
             mouseEventSource: nil,
@@ -1085,24 +1059,6 @@ final class InputProcessorTests: XCTestCase {
             ButtonCore.shared.dispatchEventTapLocation.rawValue,
             CGEventTapLocation.cgSessionEventTap.rawValue
         )
-    }
-
-    func testButtonCore_primaryObservationMask_includesPrimaryMouseButtons() {
-        let core = ButtonCore.shared
-
-        func contains(_ type: CGEventType, in mask: CGEventMask) -> Bool {
-            let typeMask = CGEventMask(1 << type.rawValue)
-            return mask & typeMask != 0
-        }
-
-        XCTAssertTrue(contains(.leftMouseDown, in: core.primaryObservationEventMask))
-        XCTAssertTrue(contains(.leftMouseUp, in: core.primaryObservationEventMask))
-        XCTAssertTrue(contains(.rightMouseDown, in: core.primaryObservationEventMask))
-        XCTAssertTrue(contains(.rightMouseUp, in: core.primaryObservationEventMask))
-        XCTAssertFalse(contains(.otherMouseDown, in: core.primaryObservationEventMask))
-        XCTAssertFalse(contains(.otherMouseUp, in: core.primaryObservationEventMask))
-        XCTAssertFalse(contains(.keyDown, in: core.primaryObservationEventMask))
-        XCTAssertFalse(contains(.keyUp, in: core.primaryObservationEventMask))
     }
 
 }


### PR DESCRIPTION
## Summary

- stop installing the no-op global event tap for primary mouse button events
- keep left/right mouse down and up events outside ButtonCore entirely
- retain the regression assertion that primary buttons are excluded from the dispatch mask

## Why

Mos 4.0.2 installs a mutable global event tap for mouse-button events. Current master already moved primary clicks out of the mutable dispatch tap, but it still installs a separate listen-only tap whose callback only returns the original event.

Applications with their own drag state machines, notably Adobe After Effects, have been reported to enter a stuck left-click state while Mos is running. Since Mos does not record an unmodified primary click and the observation callback has no behavior, subscribing to those events adds input-path risk without providing functionality.

This change removes that remaining primary-button tap so Mos never observes or rewrites physical left/right clicks through ButtonCore.

Addresses #843.

## Validation

- `git diff --check`
- `xcrun swiftc -parse Mos/ButtonCore/ButtonCore.swift MosTests/InputProcessorTests.swift`
- `xcodebuild -scheme Debug -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -scheme Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test -only-testing:MosTests/InputProcessorTests` — 48 tests passed with 0 failures
- existing `testButtonCore_dispatchEventMask_excludesPrimaryMouseButtons` regression coverage passed
- runtime check on macOS 26.2 with Adobe After Effects 26.3.0: no stuck click observed during approximately 10–17 minutes of timeline/composition dragging and normal editing

Additional maintainer/community verification on other macOS and After Effects versions is welcome.
