### PR TITLE
fix(options): preserve scroll step/speed/duration defaults when prefs keys are missing

### DIFF
--- a/Mos.xcodeproj/project.pbxproj
+++ b/Mos.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C3D4E5F6A7B8C9D0E1F30200 /* MosTests/InputProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F30201 /* MosTests/InputProcessorTests.swift */; };
 		C4E5F6A7B8C9D0E1F3020200 /* MosTests/ButtonCapturePresentationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E5F6A7B8C9D0E1F3020201 /* MosTests/ButtonCapturePresentationStatusTests.swift */; };
 		C7A1B2C3D4E5F60718293A4B /* MosTests/OptionsChangePropagationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */; };
+		F1A5C3D400000000000000B0 /* MosTests/OptionsScrollDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A5C3D400000000000000B1 /* MosTests/OptionsScrollDefaultsTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01000 /* MosTests/LogiDivertPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01001 /* MosTests/LogiDivertPlannerTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01100 /* MosTests/LogiConflictDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01101 /* MosTests/LogiConflictDetectorTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01200 /* MosTests/LogiReportingDidCompleteEmptyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01201 /* MosTests/LogiReportingDidCompleteEmptyPathTests.swift */; };
@@ -84,6 +85,7 @@
 		C3D4E5F6A7B8C9D0E1F30201 /* MosTests/InputProcessorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/InputProcessorTests.swift; sourceTree = SOURCE_ROOT; };
 		C4E5F6A7B8C9D0E1F3020201 /* MosTests/ButtonCapturePresentationStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ButtonCapturePresentationStatusTests.swift; sourceTree = SOURCE_ROOT; };
 		C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/OptionsChangePropagationTests.swift; sourceTree = SOURCE_ROOT; };
+		F1A5C3D400000000000000B1 /* MosTests/OptionsScrollDefaultsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/OptionsScrollDefaultsTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01001 /* MosTests/LogiDivertPlannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiDivertPlannerTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01101 /* MosTests/LogiConflictDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiConflictDetectorTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01201 /* MosTests/LogiReportingDidCompleteEmptyPathTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiReportingDidCompleteEmptyPathTests.swift; sourceTree = SOURCE_ROOT; };
@@ -204,6 +206,7 @@
 				D3A1B2C3D4E5F60718293A51 /* MosTests/ScrollActionPortTests.swift */,
 				D3A1B2C3D4E5F60718293A61 /* MosTests/ScrollPosterConfigSnapshotTests.swift */,
 				C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */,
+				F1A5C3D400000000000000B1 /* MosTests/OptionsScrollDefaultsTests.swift */,
 				E1B8B50E951D72C6195DBA3A /* MosTests/ScrollEventTests.swift */,
 				31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */,
 				E7D69BB23DED610DCD5A0103 /* MosTests/ScrollHotkeyTests.swift */,
@@ -420,6 +423,7 @@
 				D3A1B2C3D4E5F60718293A50 /* MosTests/ScrollActionPortTests.swift in Sources */,
 				D3A1B2C3D4E5F60718293A60 /* MosTests/ScrollPosterConfigSnapshotTests.swift in Sources */,
 				C7A1B2C3D4E5F60718293A4B /* MosTests/OptionsChangePropagationTests.swift in Sources */,
+				F1A5C3D400000000000000B0 /* MosTests/OptionsScrollDefaultsTests.swift in Sources */,
 				296126EA068FF77D423ACAA9 /* MosTests/ScrollEventTests.swift in Sources */,
 				BF0CC4D63CC0E5FE8FCF6E01 /* MosTests/ScrollFilterTests.swift in Sources */,
 				568F976CF65380A55E73E588 /* MosTests/ScrollHotkeyTests.swift in Sources */,

--- a/Mos/Options/Options.swift
+++ b/Mos/Options/Options.swift
@@ -194,9 +194,21 @@ extension Options {
         scroll.dash = loadScrollHotkey(forKey: OptionItem.Scroll.Dash, default: OPTIONS_SCROLL_DEFAULT().dash)
         scroll.toggle = loadScrollHotkey(forKey: OptionItem.Scroll.Toggle, default: OPTIONS_SCROLL_DEFAULT().toggle)
         scroll.block = loadScrollHotkey(forKey: OptionItem.Scroll.Block, default: OPTIONS_SCROLL_DEFAULT().block)
-        scroll.step = UserDefaults.standard.double(forKey: OptionItem.Scroll.Step)
-        scroll.speed = UserDefaults.standard.double(forKey: OptionItem.Scroll.Speed)
-        scroll.duration = UserDefaults.standard.double(forKey: OptionItem.Scroll.Duration)
+        if let storedStep = UserDefaults.standard.object(forKey: OptionItem.Scroll.Step) as? Double {
+            scroll.step = storedStep
+        } else {
+            scroll.step = OPTIONS_SCROLL_DEFAULT().step
+        }
+        if let storedSpeed = UserDefaults.standard.object(forKey: OptionItem.Scroll.Speed) as? Double {
+            scroll.speed = storedSpeed
+        } else {
+            scroll.speed = OPTIONS_SCROLL_DEFAULT().speed
+        }
+        if let storedDuration = UserDefaults.standard.object(forKey: OptionItem.Scroll.Duration) as? Double {
+            scroll.duration = storedDuration
+        } else {
+            scroll.duration = OPTIONS_SCROLL_DEFAULT().duration
+        }
         if let storedDeadZone = UserDefaults.standard.object(forKey: OptionItem.Scroll.DeadZone) as? Double {
             scroll.deadZone = storedDeadZone
         } else {

--- a/MosTests/OptionsScrollDefaultsTests.swift
+++ b/MosTests/OptionsScrollDefaultsTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import Mos_Debug
+
+/// Regression tests for `Options.readOptions()`: the scroll `step` / `speed` /
+/// `duration` defaults (33.6 / 2.70 / 4.35) must survive a missing UserDefaults
+/// key — mirroring the existing `deadZone` nil-guard.
+///
+/// `UserDefaults.double(forKey:)` returns `0.0` (not `nil`) for a missing key,
+/// which previously stomped those defaults. `speed == 0.0` is especially bad:
+/// `ScrollPoster.update` scales the smoothing buffer by `speed`
+/// (`buffer.y += y * speed * amplification`), so with a zero speed the buffer
+/// never accumulates and no smoothed event is ever posted — scrolling in the
+/// affected app dies entirely.
+final class OptionsScrollDefaultsTests: XCTestCase {
+
+    private let defaults = UserDefaults.standard
+
+    // UserDefaults keys touched by these tests, restored 1:1 in tearDown.
+    private var defaultsSnapshots: [(key: String, original: Any?)] = []
+    // In-memory snapshot of every scroll field readOptions() writes, so the
+    // shared singleton is left exactly as we found it.
+    private var scrollSnapshot: ScrollSnapshot?
+
+    private let expectedStep = OPTIONS_SCROLL_DEFAULT().step         // 33.6
+    private let expectedSpeed = OPTIONS_SCROLL_DEFAULT().speed       // 2.70
+    private let expectedDuration = OPTIONS_SCROLL_DEFAULT().duration // 4.35
+
+    // MARK: - Missing key falls back to the OPTIONS_SCROLL_DEFAULT() value
+
+    func testReadOptions_restoresSpeedDefault_whenKeyMissing() {
+        // Mark "options exist" so readOptions() skips its first-run re-seed and
+        // exercises the read path directly — modelling a partial-write state
+        // where optionsExist is set but a scroll key is absent.
+        snapshotUserDefaultsAndSet(OptionItem.General.OptionsExist, to: "optionsExist")
+        snapshotUserDefaultsAndRemove(OptionItem.Scroll.Speed)
+        Options.shared.readOptions()
+        XCTAssertEqual(Options.shared.scroll.speed, expectedSpeed, accuracy: 1e-9,
+                       "speed must fall back to 2.70 when its key is missing, not 0.0")
+    }
+
+    func testReadOptions_restoresStepAndDurationDefaults_whenKeysMissing() {
+        snapshotUserDefaultsAndSet(OptionItem.General.OptionsExist, to: "optionsExist")
+        snapshotUserDefaultsAndRemove(OptionItem.Scroll.Step)
+        snapshotUserDefaultsAndRemove(OptionItem.Scroll.Duration)
+        Options.shared.readOptions()
+        XCTAssertEqual(Options.shared.scroll.step, expectedStep, accuracy: 1e-9,
+                       "step must fall back to 33.6 when its key is missing, not 0.0")
+        XCTAssertEqual(Options.shared.scroll.duration, expectedDuration, accuracy: 1e-9,
+                       "duration must fall back to 4.35 when its key is missing, not 0.0")
+    }
+
+    // MARK: - A genuinely stored value is honoured (regression guard)
+
+    func testReadOptions_keepsStoredValue_whenKeyPresent() {
+        snapshotUserDefaultsAndSet(OptionItem.General.OptionsExist, to: "optionsExist")
+        snapshotUserDefaultsAndSet(OptionItem.Scroll.Speed, to: 5.0)
+        Options.shared.readOptions()
+        XCTAssertEqual(Options.shared.scroll.speed, 5.0, accuracy: 1e-9,
+                       "a real stored speed must not be overwritten by the default")
+    }
+
+    // MARK: - Invariant: a missing speed key must never deaden scrolling
+
+    func testReadOptions_doesNotDeadenScrolling_whenSpeedKeyMissing() {
+        // The default speed is the contract that scrolling keeps working even
+        // when the key is absent; it must never resolve to 0.
+        XCTAssertNotEqual(OPTIONS_SCROLL_DEFAULT().speed, 0.0)
+        snapshotUserDefaultsAndSet(OptionItem.General.OptionsExist, to: "optionsExist")
+        snapshotUserDefaultsAndRemove(OptionItem.Scroll.Speed)
+        Options.shared.readOptions()
+        XCTAssertNotEqual(Options.shared.scroll.speed, 0.0,
+                          "missing speed key must never resolve to 0.0 (deadens scrolling)")
+    }
+
+    // MARK: - setUp / tearDown
+
+    override func setUp() {
+        super.setUp()
+        scrollSnapshot = ScrollSnapshot(of: Options.shared.scroll)
+    }
+
+    override func tearDown() {
+        // Restore UserDefaults first, then write the captured in-memory values
+        // back into the shared singleton.
+        for snapshot in defaultsSnapshots {
+            if let original = snapshot.original {
+                defaults.set(original, forKey: snapshot.key)
+            } else {
+                defaults.removeObject(forKey: snapshot.key)
+            }
+        }
+        defaultsSnapshots.removeAll()
+        scrollSnapshot?.restore(into: Options.shared.scroll)
+        scrollSnapshot = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func snapshotUserDefaultsAndRemove(_ key: String) {
+        defaultsSnapshots.append((key: key, original: defaults.object(forKey: key)))
+        defaults.removeObject(forKey: key)
+    }
+
+    private func snapshotUserDefaultsAndSet(_ key: String, to value: Any) {
+        defaultsSnapshots.append((key: key, original: defaults.object(forKey: key)))
+        defaults.set(value, forKey: key)
+    }
+}
+
+/// Value snapshot of the mutable `OPTIONS_SCROLL_DEFAULT` fields that
+/// `readOptions()` writes, for deterministic single-instance teardown.
+private struct ScrollSnapshot {
+    let smooth: Bool
+    let reverse: Bool
+    let reverseVertical: Bool
+    let reverseHorizontal: Bool
+    let dash: ScrollHotkey?
+    let toggle: ScrollHotkey?
+    let block: ScrollHotkey?
+    let step: Double
+    let speed: Double
+    let duration: Double
+    let deadZone: Double
+    let smoothSimTrackpad: Bool
+    let smoothVertical: Bool
+    let smoothHorizontal: Bool
+    let durationBeforeSimTrackpadLock: Double?
+
+    init(of scroll: OPTIONS_SCROLL_DEFAULT) {
+        self.smooth = scroll.smooth
+        self.reverse = scroll.reverse
+        self.reverseVertical = scroll.reverseVertical
+        self.reverseHorizontal = scroll.reverseHorizontal
+        self.dash = scroll.dash
+        self.toggle = scroll.toggle
+        self.block = scroll.block
+        self.step = scroll.step
+        self.speed = scroll.speed
+        self.duration = scroll.duration
+        self.deadZone = scroll.deadZone
+        self.smoothSimTrackpad = scroll.smoothSimTrackpad
+        self.smoothVertical = scroll.smoothVertical
+        self.smoothHorizontal = scroll.smoothHorizontal
+        self.durationBeforeSimTrackpadLock = scroll.durationBeforeSimTrackpadLock
+    }
+
+    func restore(into scroll: OPTIONS_SCROLL_DEFAULT) {
+        scroll.smooth = smooth
+        scroll.reverse = reverse
+        scroll.reverseVertical = reverseVertical
+        scroll.reverseHorizontal = reverseHorizontal
+        scroll.dash = dash
+        scroll.toggle = toggle
+        scroll.block = block
+        scroll.step = step
+        scroll.speed = speed
+        scroll.duration = duration
+        scroll.deadZone = deadZone
+        scroll.smoothSimTrackpad = smoothSimTrackpad
+        scroll.smoothVertical = smoothVertical
+        scroll.smoothHorizontal = smoothHorizontal
+        scroll.durationBeforeSimTrackpadLock = durationBeforeSimTrackpadLock
+    }
+}


### PR DESCRIPTION
`Options.readOptions()` read the scroll `step` / `speed` / `duration` with `UserDefaults.double(forKey:)`, which returns `0.0` when the key is missing (not `nil`) — silently stomping the `OPTIONS_SCROLL_DEFAULT()` values (`33.6` / `2.70` / `4.35`). With `speed == 0.0`, scrolling in the affected app dies entirely: the smoothing buffer in `ScrollPoster.update` never accumulates (`buffer.y += y * speed * amplification`), and if `smooth` is enabled the original event is swallowed while no smoothed event is posted.

Three lines below, the same block already guards `deadZone` correctly via `object(forKey:) as? Double` with a fallback to the default. This PR extends that exact pattern to the three numeric fields.

## Trigger
Not only a manual `defaults delete`: `saveOptions()` writes the `optionsExist` flag *before* the `.scroll` group, and UserDefaults isn't atomic across keys — a crash in that window leaves `optionsExist != nil` but `step`/`speed`/`duration` absent, so the next launch reads three zeros. The existing `deadZone` guard (and `loadScrollHotkey` migration) exist for exactly this forward/backward-compat class.

## Changes
- `Mos/Options/Options.swift`: guard each of `step` / `speed` / `duration` with `object(forKey:) as? Double`, falling back to `OPTIONS_SCROLL_DEFAULT()`. Behaviour changes only when the key is genuinely absent — exactly when the default is wanted; already-configured users are unaffected.
- `MosTests/OptionsScrollDefaultsTests.swift` (new): restores defaults when keys missing (speed; step + duration), and keeps a stored value when present (regression guard).
- `Mos.xcodeproj/project.pbxproj`: test-target membership for the new file.

## Test plan
`xcodebuild -scheme Debug -destination 'platform=macOS' test -only-testing:MosTests/OptionsScrollDefaultsTests` — **4 passed, 0 failed** (red before the fix: `speed` read `0.0` instead of `2.70`).