### PR TITLE
fix(scroll): honor per-app axis sub-toggle overrides when global axis is off

### DIFF
--- a/Mos.xcodeproj/project.pbxproj
+++ b/Mos.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C3D4E5F6A7B8C9D0E1F30200 /* MosTests/InputProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F30201 /* MosTests/InputProcessorTests.swift */; };
 		C4E5F6A7B8C9D0E1F3020200 /* MosTests/ButtonCapturePresentationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E5F6A7B8C9D0E1F3020201 /* MosTests/ButtonCapturePresentationStatusTests.swift */; };
 		C7A1B2C3D4E5F60718293A4B /* MosTests/OptionsChangePropagationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */; };
+		C7A1B2C3D4E5F60718293A5B /* MosTests/ApplicationScrollAxisOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1B2C3D4E5F60718293A5C /* MosTests/ApplicationScrollAxisOverrideTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01000 /* MosTests/LogiDivertPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01001 /* MosTests/LogiDivertPlannerTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01100 /* MosTests/LogiConflictDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01101 /* MosTests/LogiConflictDetectorTests.swift */; };
 		D1A2B3C4E5F6A7B8C9D01200 /* MosTests/LogiReportingDidCompleteEmptyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F6A7B8C9D01201 /* MosTests/LogiReportingDidCompleteEmptyPathTests.swift */; };
@@ -84,6 +85,7 @@
 		C3D4E5F6A7B8C9D0E1F30201 /* MosTests/InputProcessorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/InputProcessorTests.swift; sourceTree = SOURCE_ROOT; };
 		C4E5F6A7B8C9D0E1F3020201 /* MosTests/ButtonCapturePresentationStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ButtonCapturePresentationStatusTests.swift; sourceTree = SOURCE_ROOT; };
 		C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/OptionsChangePropagationTests.swift; sourceTree = SOURCE_ROOT; };
+		C7A1B2C3D4E5F60718293A5C /* MosTests/ApplicationScrollAxisOverrideTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ApplicationScrollAxisOverrideTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01001 /* MosTests/LogiDivertPlannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiDivertPlannerTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01101 /* MosTests/LogiConflictDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiConflictDetectorTests.swift; sourceTree = SOURCE_ROOT; };
 		D1A2B3C4E5F6A7B8C9D01201 /* MosTests/LogiReportingDidCompleteEmptyPathTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/LogiReportingDidCompleteEmptyPathTests.swift; sourceTree = SOURCE_ROOT; };
@@ -204,6 +206,7 @@
 				D3A1B2C3D4E5F60718293A51 /* MosTests/ScrollActionPortTests.swift */,
 				D3A1B2C3D4E5F60718293A61 /* MosTests/ScrollPosterConfigSnapshotTests.swift */,
 				C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */,
+				C7A1B2C3D4E5F60718293A5C /* MosTests/ApplicationScrollAxisOverrideTests.swift */,
 				E1B8B50E951D72C6195DBA3A /* MosTests/ScrollEventTests.swift */,
 				31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */,
 				E7D69BB23DED610DCD5A0103 /* MosTests/ScrollHotkeyTests.swift */,
@@ -420,6 +423,7 @@
 				D3A1B2C3D4E5F60718293A50 /* MosTests/ScrollActionPortTests.swift in Sources */,
 				D3A1B2C3D4E5F60718293A60 /* MosTests/ScrollPosterConfigSnapshotTests.swift in Sources */,
 				C7A1B2C3D4E5F60718293A4B /* MosTests/OptionsChangePropagationTests.swift in Sources */,
+				C7A1B2C3D4E5F60718293A5B /* MosTests/ApplicationScrollAxisOverrideTests.swift in Sources */,
 				296126EA068FF77D423ACAA9 /* MosTests/ScrollEventTests.swift in Sources */,
 				BF0CC4D63CC0E5FE8FCF6E01 /* MosTests/ScrollFilterTests.swift in Sources */,
 				568F976CF65380A55E73E588 /* MosTests/ScrollHotkeyTests.swift in Sources */,

--- a/Mos/Windows/PreferencesWindow/ApplicationView/Application.swift
+++ b/Mos/Windows/PreferencesWindow/ApplicationView/Application.swift
@@ -90,27 +90,23 @@ extension Application {
     }
     func isReverseVertical() -> Bool {
         if !Options.shared.scroll.reverse { return false }
-        if !Options.shared.scroll.reverseVertical { return false }
         let target = resolvedScrollOptions()
         return target.reverse && target.reverseVertical
     }
     func isReverseHorizontal() -> Bool {
         if !Options.shared.scroll.reverse { return false }
-        if !Options.shared.scroll.reverseHorizontal { return false }
         let target = resolvedScrollOptions()
         return target.reverse && target.reverseHorizontal
     }
     func isSmoothVertical(_ block: Bool) -> Bool {
         if block { return false }
         if !Options.shared.scroll.smooth { return false }
-        if !Options.shared.scroll.smoothVertical { return false }
         let target = resolvedScrollOptions()
         return target.smooth && target.smoothVertical
     }
     func isSmoothHorizontal(_ block: Bool) -> Bool {
         if block { return false }
         if !Options.shared.scroll.smooth { return false }
-        if !Options.shared.scroll.smoothHorizontal { return false }
         let target = resolvedScrollOptions()
         return target.smooth && target.smoothHorizontal
     }

--- a/MosTests/ApplicationScrollAxisOverrideTests.swift
+++ b/MosTests/ApplicationScrollAxisOverrideTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import Mos_Debug
+
+/**
+ * Per-app scroll axis sub-toggle (smooth/reverse × vertical/horizontal) overrides.
+ *
+ * These methods read the GLOBAL master toggle (`Options.shared.scroll.smooth` /
+ * `reverse`) plus the resolved per-app target (`resolvedScrollOptions()`). They must
+ * NOT also gate on the GLOBAL axis sub-toggle — otherwise a per-app (inherit=false)
+ * checkbox that shows ON+enabled is silently ignored at runtime whenever the
+ * corresponding global axis sub-toggle is off.
+ */
+final class ApplicationScrollAxisOverrideTests: XCTestCase {
+
+    // Saved global scroll axis flags — restored in tearDown so every test starts clean.
+    private var savedSmooth = false
+    private var savedReverse = false
+    private var savedSmoothVertical = false
+    private var savedSmoothHorizontal = false
+    private var savedReverseVertical = false
+    private var savedReverseHorizontal = false
+
+    override func setUp() {
+        super.setUp()
+        let scroll = Options.shared.scroll
+        savedSmooth = scroll.smooth
+        savedReverse = scroll.reverse
+        savedSmoothVertical = scroll.smoothVertical
+        savedSmoothHorizontal = scroll.smoothHorizontal
+        savedReverseVertical = scroll.reverseVertical
+        savedReverseHorizontal = scroll.reverseHorizontal
+    }
+
+    override func tearDown() {
+        let scroll = Options.shared.scroll
+        scroll.smooth = savedSmooth
+        scroll.reverse = savedReverse
+        scroll.smoothVertical = savedSmoothVertical
+        scroll.smoothHorizontal = savedSmoothHorizontal
+        scroll.reverseVertical = savedReverseVertical
+        scroll.reverseHorizontal = savedReverseHorizontal
+        super.tearDown()
+    }
+
+    // MARK: - Per-app override honored when the GLOBAL axis sub-toggle is off (inherit = false)
+
+    /// Per-app smoothVertical=true (inherit=false) must override a globally-disabled smoothVertical.
+    func testPerAppSmoothVerticalOverridesGlobalDisabledAxis() {
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.smoothVertical = false
+        let app = Application(path: "/X")
+        app.inherit = false
+        app.scroll.smooth = true
+        app.scroll.smoothVertical = true
+        XCTAssertTrue(app.isSmoothVertical(false),
+            "per-app smoothVertical=true (inherit=false) must override global smoothVertical=false")
+    }
+
+    /// Per-app smoothHorizontal=true (inherit=false) must override a globally-disabled smoothHorizontal.
+    func testPerAppSmoothHorizontalOverridesGlobalDisabledAxis() {
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.smoothHorizontal = false
+        let app = Application(path: "/X")
+        app.inherit = false
+        app.scroll.smooth = true
+        app.scroll.smoothHorizontal = true
+        XCTAssertTrue(app.isSmoothHorizontal(false),
+            "per-app smoothHorizontal=true (inherit=false) must override global smoothHorizontal=false")
+    }
+
+    /// Per-app reverseVertical=true (inherit=false) must override a globally-disabled reverseVertical.
+    func testPerAppReverseVerticalOverridesGlobalDisabledAxis() {
+        Options.shared.scroll.reverse = true
+        Options.shared.scroll.reverseVertical = false
+        let app = Application(path: "/X")
+        app.inherit = false
+        app.scroll.reverse = true
+        app.scroll.reverseVertical = true
+        XCTAssertTrue(app.isReverseVertical(),
+            "per-app reverseVertical=true (inherit=false) must override global reverseVertical=false")
+    }
+
+    /// Per-app reverseHorizontal=true (inherit=false) must override a globally-disabled reverseHorizontal.
+    func testPerAppReverseHorizontalOverridesGlobalDisabledAxis() {
+        Options.shared.scroll.reverse = true
+        Options.shared.scroll.reverseHorizontal = false
+        let app = Application(path: "/X")
+        app.inherit = false
+        app.scroll.reverse = true
+        app.scroll.reverseHorizontal = true
+        XCTAssertTrue(app.isReverseHorizontal(),
+            "per-app reverseHorizontal=true (inherit=false) must override global reverseHorizontal=false")
+    }
+
+    // MARK: - inherit = true behavior preservation (must stay false when the global axis is off)
+
+    /// inherit=true must follow the global smoothVertical (off here), unchanged by the fix.
+    func testInheritTrueSmoothVerticalFollowsGlobalDisabledAxis() {
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.smoothVertical = false
+        let app = Application(path: "/X")
+        app.inherit = true
+        XCTAssertFalse(app.isSmoothVertical(false),
+            "inherit=true must follow global smoothVertical=false")
+    }
+
+    /// inherit=true must follow the global smoothHorizontal (off here), unchanged by the fix.
+    func testInheritTrueSmoothHorizontalFollowsGlobalDisabledAxis() {
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.smoothHorizontal = false
+        let app = Application(path: "/X")
+        app.inherit = true
+        XCTAssertFalse(app.isSmoothHorizontal(false),
+            "inherit=true must follow global smoothHorizontal=false")
+    }
+
+    /// inherit=true must follow the global reverseVertical (off here), unchanged by the fix.
+    func testInheritTrueReverseVerticalFollowsGlobalDisabledAxis() {
+        Options.shared.scroll.reverse = true
+        Options.shared.scroll.reverseVertical = false
+        let app = Application(path: "/X")
+        app.inherit = true
+        XCTAssertFalse(app.isReverseVertical(),
+            "inherit=true must follow global reverseVertical=false")
+    }
+
+    /// inherit=true must follow the global reverseHorizontal (off here), unchanged by the fix.
+    func testInheritTrueReverseHorizontalFollowsGlobalDisabledAxis() {
+        Options.shared.scroll.reverse = true
+        Options.shared.scroll.reverseHorizontal = false
+        let app = Application(path: "/X")
+        app.inherit = true
+        XCTAssertFalse(app.isReverseHorizontal(),
+            "inherit=true must follow global reverseHorizontal=false")
+    }
+
+    // MARK: - block flag + per-app master toggle still respected (proves the fix is surgical)
+
+    /// block=true must short-circuit isSmooth* to false regardless of a per-app override.
+    func testSmoothBlockFlagShortCircuitsOverride() {
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.smoothVertical = true
+        let app = Application(path: "/X")
+        app.inherit = false
+        app.scroll.smooth = true
+        app.scroll.smoothVertical = true
+        XCTAssertFalse(app.isSmoothVertical(true),
+            "block=true must force isSmoothVertical false even when the override is on")
+    }
+
+    /// A per-app that turns the master toggle off must still disable that feature for the app.
+    func testPerAppMasterOffDisablesFeature() {
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.smoothVertical = true
+        let app = Application(path: "/X")
+        app.inherit = false
+        app.scroll.smooth = false        // master off for this app
+        app.scroll.smoothVertical = true
+        XCTAssertFalse(app.isSmoothVertical(false),
+            "per-app smooth=false (inherit=false) must disable smoothVertical for the app")
+    }
+}


### PR DESCRIPTION
fix(scroll): honor per-app axis sub-toggle overrides when global axis is off

The four per-app axis resolution methods (isReverseVertical,
isReverseHorizontal, isSmoothVertical, isSmoothHorizontal) each carried a
spurious guard on the GLOBAL axis sub-toggle on top of the intended master
gate. When a per-app (inherit=false) enabled an axis sub-toggle that was off
globally, the checkbox showed ON+enabled but the runtime silently ignored it.

Drop the redundant global-axis guard so the methods mirror the already-correct
isSmooth/isReverse (master gate + resolved per-app target). The master gate
(Options.shared.scroll.smooth/reverse) and the block flag are preserved; a
per-app can still disable the master for that app. The inherit=true path is
unchanged (resolvedScrollOptions() returns the global object either way).

Adds MosTests/ApplicationScrollAxisOverrideTests.swift (10 pure-logic tests,
red->green). Full suite: 546 tests, 0 failures.

Co-Authored-By: Claude <noreply@anthropic.com>

