### PR TITLE
fix(utils): honor pattern argument in extractRegexMatches

### DIFF
--- a/Mos.xcodeproj/project.pbxproj
+++ b/Mos.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		B2C3D4E5F6A7B8C9D0E1F200 /* MosTests/ButtonUtilsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F201 /* MosTests/ButtonUtilsCacheTests.swift */; };
 		B3D4E5F6A7B8C9D0E1F40100 /* MosTests/MouseInteractionSessionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D4E5F6A7B8C9D0E1F40101 /* MosTests/MouseInteractionSessionControllerTests.swift */; };
 		BF0CC4D63CC0E5FE8FCF6E01 /* MosTests/ScrollFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */; };
+		F1A2B3C4D5E6F7081920A1B1 /* MosTests/ExtractRegexPatternArgTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7081920A1B2 /* MosTests/ExtractRegexPatternArgTests.swift */; };
 		C3D4E5F6A7B8C9D0E1F30200 /* MosTests/InputProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F30201 /* MosTests/InputProcessorTests.swift */; };
 		C4E5F6A7B8C9D0E1F3020200 /* MosTests/ButtonCapturePresentationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E5F6A7B8C9D0E1F3020201 /* MosTests/ButtonCapturePresentationStatusTests.swift */; };
 		C7A1B2C3D4E5F60718293A4B /* MosTests/OptionsChangePropagationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */; };
@@ -76,6 +77,7 @@
 		2D6CF5441214A14BB8FFEDA5 /* MosTests/ScrollCoreHotkeyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollCoreHotkeyTests.swift; sourceTree = SOURCE_ROOT; };
 		2F59E07FB2E69806EAED5405 /* MosTests/ScrollPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollPhaseTests.swift; sourceTree = SOURCE_ROOT; };
 		31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollFilterTests.swift; sourceTree = SOURCE_ROOT; };
+		F1A2B3C4D5E6F7081920A1B2 /* MosTests/ExtractRegexPatternArgTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ExtractRegexPatternArgTests.swift; sourceTree = SOURCE_ROOT; };
 		9CCA64306C761E8CA5D0759A /* MosTests/ScrollPosterStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollPosterStateTests.swift; sourceTree = SOURCE_ROOT; };
 		9D4A7F821E5626C63C45D698 /* MosTests/InterpolatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/InterpolatorTests.swift; sourceTree = SOURCE_ROOT; };
 		A1B2C3D4E5F6A7B8C9D0E1F3 /* MosTests/ButtonBindingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ButtonBindingTests.swift; sourceTree = SOURCE_ROOT; };
@@ -206,6 +208,7 @@
 				C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */,
 				E1B8B50E951D72C6195DBA3A /* MosTests/ScrollEventTests.swift */,
 				31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */,
+				F1A2B3C4D5E6F7081920A1B2 /* MosTests/ExtractRegexPatternArgTests.swift */,
 				E7D69BB23DED610DCD5A0103 /* MosTests/ScrollHotkeyTests.swift */,
 				2F59E07FB2E69806EAED5405 /* MosTests/ScrollPhaseTests.swift */,
 				9CCA64306C761E8CA5D0759A /* MosTests/ScrollPosterStateTests.swift */,
@@ -422,6 +425,7 @@
 				C7A1B2C3D4E5F60718293A4B /* MosTests/OptionsChangePropagationTests.swift in Sources */,
 				296126EA068FF77D423ACAA9 /* MosTests/ScrollEventTests.swift in Sources */,
 				BF0CC4D63CC0E5FE8FCF6E01 /* MosTests/ScrollFilterTests.swift in Sources */,
+				F1A2B3C4D5E6F7081920A1B1 /* MosTests/ExtractRegexPatternArgTests.swift in Sources */,
 				568F976CF65380A55E73E588 /* MosTests/ScrollHotkeyTests.swift in Sources */,
 				9ACEB06D964AE340A82C0792 /* MosTests/ScrollPhaseTests.swift in Sources */,
 				754D86BF951F4E0C56F76E8D /* MosTests/ScrollPosterStateTests.swift in Sources */,

--- a/Mos/Utils/Utils.swift
+++ b/Mos/Utils/Utils.swift
@@ -164,7 +164,6 @@ public class Utils {
     // 匹配字符
     class func extractRegexMatches(target: String = "", pattern: String) -> String {
         do {
-            let pattern = #"\/?.*\.app"#
             let regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
             let range = NSRange(location: 0, length: target.count)
             let result = regex.firstMatch(in: target, options: [], range: range)

--- a/MosTests/ExtractRegexPatternArgTests.swift
+++ b/MosTests/ExtractRegexPatternArgTests.swift
@@ -1,0 +1,36 @@
+//
+//  ExtractRegexPatternArgTests.swift
+//  MosTests
+//
+//  Regression: Utils.extractRegexMatches must honor its `pattern` argument.
+//
+
+import XCTest
+@testable import Mos_Debug
+
+final class ExtractRegexPatternArgTests: XCTestCase {
+
+    /// `extractRegexMatches` declares a `pattern` parameter, so callers expect it
+    /// to drive the regex. Passing a non-`.app` pattern must extract accordingly.
+    func testExtractRegexMatches_honorsPassedPattern() {
+        // A digit run: only matchable when the caller-supplied pattern is used.
+        let target = "abc123def"
+        let extracted = Utils.extractRegexMatches(target: target, pattern: "[0-9]+")
+        XCTAssertEqual(extracted, "123",
+                       "extractRegexMatches must use the passed pattern; before the fix a hardcoded `.app` literal shadowed the parameter and returned the whole target unchanged.")
+    }
+
+    /// The existing in-tree call sites pass an `.app` pattern; that behaviour must be preserved.
+    func testExtractRegexMatches_preservesAppPathBehaviour() {
+        let target = "/Applications/Safari.app"
+        let extracted = Utils.extractRegexMatches(target: target, pattern: #"\/?.*\.app"#)
+        XCTAssertEqual(extracted, "/Applications/Safari.app")
+    }
+
+    /// When the supplied pattern does not match, the whole target is returned (documented fallback).
+    func testExtractRegexMatches_noMatch_returnsTarget() {
+        let target = "/Applications/Safari.app"
+        let extracted = Utils.extractRegexMatches(target: target, pattern: "[0-9]+")
+        XCTAssertEqual(extracted, target)
+    }
+}


### PR DESCRIPTION
## Summary

`Utils.extractRegexMatches(target:pattern:)` declared a `pattern` parameter but never actually used it: a hardcoded local `let pattern = #"\/?.*\.app"#` shadowed it inside the `do` block, so every caller was forced through the `.app` extractor regardless of the argument passed.

## Root cause

Variable shadowing — the parameter `pattern` is rebound by a local constant of the same name on the very next line, so the argument is discarded:

```swift
class func extractRegexMatches(target: String = "", pattern: String) -> String {
    do {
        let pattern = #"\/?.*\.app"#   // <-- shadows the parameter
        let regex = try NSRegularExpression(pattern: pattern, ...)
```

This is the same family of latent-signature bug as the equality-typo fixed in #909: the function's contract (it takes a `pattern`) does not match its behaviour (it always uses `.app`).

## What changed

- `Mos/Utils/Utils.swift` — remove the shadowing `let pattern = …` line so the `pattern` argument drives the regex. All current in-tree call sites already pass `#"\/?.*\.app"#` explicitly, so this changes no existing behaviour; it only makes the declared parameter mean what it says.
- `MosTests/ExtractRegexPatternArgTests.swift` (new) + project registration — regression test that (a) passes a non-`.app` pattern and asserts it is honoured, (b) preserves the existing `.app`-path extraction behaviour, (c) covers the documented no-match fallback.

## Validation

Run on macOS (Darwin 25.6.0, Apple Silicon), Xcode 26.4.1, `Debug` scheme. The repo ships no Swift CI, so local validation is the gate:

```sh
xcodebuild -scheme Debug -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build -derivedDataPath /tmp/mos-dd
xcodebuild -scheme Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test \
    -only-testing:MosTests/ExtractRegexPatternArgTests -derivedDataPath /tmp/mos-dd
```

Build green; the new test class is 3/3 green **after** the fix (and red before it — with the shadow in place the `[0-9]+` case returns the whole target instead of `"123"`). `CODE_SIGNING_ALLOWED=NO` was used because this machine has no "Mac Development" signing identity; no `Mos Debug.app` was running during the test run.

## Compatibility / risk

None. The fix is strictly a behaviour-vs-signature reconciliation for a helper whose every current caller passes the previously-hardcoded value; no input path, persisted config, or public contract is touched.

Prepared with AI assistance per `CONTRIBUTING.md`; I understand every changed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
