### PR TITLE
fix(utils): use UTF-16 length for NSRegularExpression range in removingRegexMatches

### DIFF
--- a/Mos.xcodeproj/project.pbxproj
+++ b/Mos.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B3D4E5F6A7B8C9D0E1F40100 /* MosTests/MouseInteractionSessionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D4E5F6A7B8C9D0E1F40101 /* MosTests/MouseInteractionSessionControllerTests.swift */; };
 		BF0CC4D63CC0E5FE8FCF6E01 /* MosTests/ScrollFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */; };
 		F1A2B3C4D5E6F7081920A1B1 /* MosTests/ExtractRegexPatternArgTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7081920A1B2 /* MosTests/ExtractRegexPatternArgTests.swift */; };
+		F2B3C4D5E6F7081920A1B2C3 /* MosTests/RemovingRegexUTF16RangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B3C4D5E6F7081920A1B2C4 /* MosTests/RemovingRegexUTF16RangeTests.swift */; };
 		C3D4E5F6A7B8C9D0E1F30200 /* MosTests/InputProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F6A7B8C9D0E1F30201 /* MosTests/InputProcessorTests.swift */; };
 		C4E5F6A7B8C9D0E1F3020200 /* MosTests/ButtonCapturePresentationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E5F6A7B8C9D0E1F3020201 /* MosTests/ButtonCapturePresentationStatusTests.swift */; };
 		C7A1B2C3D4E5F60718293A4B /* MosTests/OptionsChangePropagationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1B2C3D4E5F60718293A4C /* MosTests/OptionsChangePropagationTests.swift */; };
@@ -78,6 +79,7 @@
 		2F59E07FB2E69806EAED5405 /* MosTests/ScrollPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollPhaseTests.swift; sourceTree = SOURCE_ROOT; };
 		31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollFilterTests.swift; sourceTree = SOURCE_ROOT; };
 		F1A2B3C4D5E6F7081920A1B2 /* MosTests/ExtractRegexPatternArgTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ExtractRegexPatternArgTests.swift; sourceTree = SOURCE_ROOT; };
+		F2B3C4D5E6F7081920A1B2C4 /* MosTests/RemovingRegexUTF16RangeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/RemovingRegexUTF16RangeTests.swift; sourceTree = SOURCE_ROOT; };
 		9CCA64306C761E8CA5D0759A /* MosTests/ScrollPosterStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollPosterStateTests.swift; sourceTree = SOURCE_ROOT; };
 		9D4A7F821E5626C63C45D698 /* MosTests/InterpolatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/InterpolatorTests.swift; sourceTree = SOURCE_ROOT; };
 		A1B2C3D4E5F6A7B8C9D0E1F3 /* MosTests/ButtonBindingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ButtonBindingTests.swift; sourceTree = SOURCE_ROOT; };
@@ -209,6 +211,7 @@
 				E1B8B50E951D72C6195DBA3A /* MosTests/ScrollEventTests.swift */,
 				31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */,
 				F1A2B3C4D5E6F7081920A1B2 /* MosTests/ExtractRegexPatternArgTests.swift */,
+				F2B3C4D5E6F7081920A1B2C4 /* MosTests/RemovingRegexUTF16RangeTests.swift */,
 				E7D69BB23DED610DCD5A0103 /* MosTests/ScrollHotkeyTests.swift */,
 				2F59E07FB2E69806EAED5405 /* MosTests/ScrollPhaseTests.swift */,
 				9CCA64306C761E8CA5D0759A /* MosTests/ScrollPosterStateTests.swift */,
@@ -426,6 +429,7 @@
 				296126EA068FF77D423ACAA9 /* MosTests/ScrollEventTests.swift in Sources */,
 				BF0CC4D63CC0E5FE8FCF6E01 /* MosTests/ScrollFilterTests.swift in Sources */,
 				F1A2B3C4D5E6F7081920A1B1 /* MosTests/ExtractRegexPatternArgTests.swift in Sources */,
+				F2B3C4D5E6F7081920A1B2C3 /* MosTests/RemovingRegexUTF16RangeTests.swift in Sources */,
 				568F976CF65380A55E73E588 /* MosTests/ScrollHotkeyTests.swift in Sources */,
 				9ACEB06D964AE340A82C0792 /* MosTests/ScrollPhaseTests.swift in Sources */,
 				754D86BF951F4E0C56F76E8D /* MosTests/ScrollPosterStateTests.swift in Sources */,

--- a/Mos/Utils/Utils.swift
+++ b/Mos/Utils/Utils.swift
@@ -180,7 +180,11 @@ public class Utils {
     class func removingRegexMatches(target: String = "", pattern: String, replaceWith: String = "") -> String {
         do {
             let regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
-            let range = NSRange(location: 0, length: target.count)
+            // NSRegularExpression operates on the UTF-16 view, so the range length must be the
+            // UTF-16 unit count, not String.count (grapheme clusters). For strings containing
+            // astral-plane characters (e.g. emoji in an app display name) the two differ and
+            // grapheme-cluster length clips the trailing units, so the suffix fails to match.
+            let range = NSRange(location: 0, length: target.utf16.count)
             return regex.stringByReplacingMatches(in: target, options: [], range: range, withTemplate: replaceWith)
         } catch {
             return target

--- a/MosTests/RemovingRegexUTF16RangeTests.swift
+++ b/MosTests/RemovingRegexUTF16RangeTests.swift
@@ -1,0 +1,44 @@
+//
+//  RemovingRegexUTF16RangeTests.swift
+//  MosTests
+//
+//  Regression: Utils.removingRegexMatches must use the UTF-16 length for the
+//  NSRegularExpression range, otherwise astral-plane characters (emoji) in an
+//  app display name clip the search range and the trailing ".app" is not stripped.
+//
+
+import XCTest
+@testable import Mos_Debug
+
+final class RemovingRegexUTF16RangeTests: XCTestCase {
+
+    /// `Utils.parseName` strips a trailing ".app" from the display name via
+    /// `removingRegexMatches(target:pattern:".app")`. When the name contains an
+    /// astral-plane character the grapheme-cluster count is shorter than the
+    /// UTF-16 count NSRegularExpression operates on, so the trailing ".app" fell
+    /// outside the range and survived. The per-app overrides list would then show
+    /// the app with an extra ".app" suffix.
+    func testRemovingRegexMatches_stripsTrailingAppSuffixOnEmojiName() {
+        // "My App🚀.app" → 11 grapheme clusters, 12 UTF-16 units (🚀 is a surrogate pair).
+        // With the grapheme-cluster length the range ended at "...ap", so ".app" never matched.
+        let name = "My App🚀.app"
+        let stripped = Utils.removingRegexMatches(target: name, pattern: "\\.app$", replaceWith: "")
+        XCTAssertEqual(stripped, "My App🚀",
+                       "trailing .app must be stripped even when the name contains an astral-plane character")
+    }
+
+    /// Pure ASCII names must continue to behave exactly as before.
+    func testRemovingRegexMatches_preservesASCIIBehaviour() {
+        XCTAssertEqual(
+            Utils.removingRegexMatches(target: "Safari.app", pattern: "\\.app$", replaceWith: ""),
+            "Safari"
+        )
+    }
+
+    /// A name made entirely of astral-plane characters plus the suffix.
+    func testRemovingRegexMatches_stripsSuffixWhenNameIsMostlyAstral() {
+        let name = "🚀🚀🚀.app"
+        let stripped = Utils.removingRegexMatches(target: name, pattern: "\\.app$", replaceWith: "")
+        XCTAssertEqual(stripped, "🚀🚀🚀")
+    }
+}


### PR DESCRIPTION
## Summary

`Utils.removingRegexMatches` built its `NSRegularExpression` search range with `NSRange(location: 0, length: target.count)` — i.e. the grapheme-cluster count. `NSRegularExpression` operates on the string's UTF-16 view, so for any target containing an astral-plane character (an emoji) the grapheme-cluster length is shorter than the UTF-16 length and the range clips the trailing units, so a suffix at the end of the string stops matching.

## Root cause

Classic Swift pitfall: `String.count` counts extended grapheme clusters, not UTF-16 code units, but `NSRegularExpression`/`NSRange` index by UTF-16 unit. For BMP-only strings the two agree; they diverge for astral-plane characters (emoji, some CJK extension chars, certain symbols).

## User-visible impact

`Utils.parseName(fromPath:)` strips a trailing `.app` from an app's display name via `removingRegexMatches(target: name, pattern: ".app")` (called from `Utils.getApplicationName`, which feeds the per-app overrides list). For a name like `My App🚀.app`:

- grapheme count = 11, UTF-16 count = 12 (`🚀` is a surrogate pair);
- with `length: target.count` the range covered UTF-16 indices 0…10, i.e. `My App🚀.ap` — the final `p` fell outside the range;
- `\.app$` then failed to match and the `.app` suffix survived, so the app showed up in the overrides list as `My App🚀.app`.

## What changed

- `Mos/Utils/Utils.swift` — use `target.utf16.count` for the `NSRange` length in `removingRegexMatches`. Pure-ASCII names are unaffected (grapheme count == UTF-16 count there).
- `MosTests/RemovingRegexUTF16RangeTests.swift` (new) + project registration — regression tests for (a) the emoji-suffix strip that was broken, (b) an all-astral name, (c) the preserved ASCII behaviour.

Note: the sibling helper `extractRegexMatches` has the same `length: target.count` shape; it is intentionally left untouched here to keep this PR to the single user-facing path (`removingRegexMatches` / `parseName`) and avoid scope creep.

## Validation

Run on macOS (Darwin 25.6.0, Apple Silicon), Xcode 26.4.1, `Debug` scheme. The repo ships no Swift CI, so local validation is the gate:

```sh
xcodebuild -scheme Debug -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build -derivedDataPath /tmp/mos-dd
xcodebuild -scheme Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test \
    -only-testing:MosTests/RemovingRegexUTF16RangeTests -derivedDataPath /tmp/mos-dd
```

Build green; the new test class is 3/3 green **after** the fix (and red before it — with the grapheme-cluster length the `.app$` case returns the name unchanged because the trailing `p` is outside the search range). `CODE_SIGNING_ALLOWED=NO` was used because this machine has no "Mac Development" signing identity; no `Mos Debug.app` was running during the test run.

## Compatibility / risk

None for ASCII inputs (unchanged path). For non-BMP inputs the behaviour changes from "silently wrong" to "correct", which is the point of the fix. No input-event path, persisted config, or public contract is touched.

Prepared with AI assistance per `CONTRIBUTING.md`; I understand every changed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
