### PR TITLE
fix(logi): restore receiver diverts after idle wake

### DIFF
--- a/Mos/Logi/Core/LogiDeviceSession.swift
+++ b/Mos/Logi/Core/LogiDeviceSession.swift
@@ -118,6 +118,14 @@ class LogiDeviceSession {
     private var pendingDeviceInfoSlots: Set<UInt8> = []
     private static let initialTargetSelectionTimeout: TimeInterval = 1.5
 
+    // Some peripherals lose temporary divert while asleep without sending the
+    // receiver's 0x41 disconnect/reconnect notification. The first report after
+    // a quiet period is the only reliable wake signal observed from those devices.
+    private static let receiverIdleWakeThreshold: TimeInterval = 60
+    private static let receiverWakeRestoreDelays: [TimeInterval] = [1.0, 2.0]
+    private var lastReceiverReportTime: [UInt8: TimeInterval] = [:]
+    private var receiverWakeRestoreWorkItems: [UInt8: [DispatchWorkItem]] = [:]
+
     // MARK: - Report Buffer
     private var reportBufferPtr: UnsafeMutablePointer<UInt8>?
     private static let reportBufferSize = 64
@@ -905,6 +913,14 @@ class LogiDeviceSession {
         return .drop
     }
 
+    static func receiverReportIndicatesWake(
+        previousTime: TimeInterval?,
+        currentTime: TimeInterval
+    ) -> Bool {
+        guard let previousTime = previousTime else { return false }
+        return currentTime - previousTime >= receiverIdleWakeThreshold
+    }
+
     /// 多设备热插拔(§Phase 4): 某 slot 的 0x41 连接/断开通知该做什么(纯决策).
     /// - 断开: 若该 slot 正被接管 -> release(释放其按键状态 + 标记未 init); 否则 ignore
     /// - 连接: 若已接管 -> ignore(防振荡, "已 init 且在线则忽略"); 否则若是 divert 候选 -> takeover
@@ -1021,6 +1037,9 @@ class LogiDeviceSession {
         receiverOptionalProbedSlots.removeAll()
         receiverTakeoverDebounce.values.forEach { $0.cancel() }
         receiverTakeoverDebounce.removeAll()
+        receiverWakeRestoreWorkItems.values.flatMap { $0 }.forEach { $0.cancel() }
+        receiverWakeRestoreWorkItems.removeAll()
+        lastReceiverReportTime.removeAll()
         discoveryTimer?.invalidate()
         discoveryTimer = nil
         controlInfoQueryTimer?.invalidate()
@@ -1436,6 +1455,40 @@ class LogiDeviceSession {
         lastApplied.removeAll()
         primeFromRegistry()
         LogiDebugPanel.log("[\(deviceInfo.name)] Re-synced divert with bindings")
+    }
+
+    private func noteReceiverPeripheralReport(slot: UInt8) {
+        let now = Date.timeIntervalSinceReferenceDate
+        let wokeFromIdle = Self.receiverReportIndicatesWake(
+            previousTime: lastReceiverReportTime[slot],
+            currentTime: now
+        )
+        lastReceiverReportTime[slot] = now
+
+        guard wokeFromIdle,
+              receiverManagedSlots.contains(slot),
+              slotStates[slot]?.reprogInitComplete == true,
+              !(slotStates[slot]?.lastApplied.isEmpty ?? true) else { return }
+
+        receiverWakeRestoreWorkItems[slot]?.forEach { $0.cancel() }
+        LogiDebugPanel.log("[\(deviceInfo.name)] Slot \(slot) resumed after idle; scheduling divert restore")
+        receiverWakeRestoreWorkItems[slot] = Self.receiverWakeRestoreDelays.map { delay in
+            let item = DispatchWorkItem { [weak self] in
+                guard let self = self,
+                      self.receiverManagedSlots.contains(slot),
+                      self.slotStates[slot]?.reprogInitComplete == true else { return }
+                let savedDeviceIndex = self.deviceIndex
+                self.deviceIndex = slot
+                self.redivertAllControls()
+                self.deviceIndex = savedDeviceIndex
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+            return item
+        }
+    }
+
+    private func cancelReceiverWakeRestore(slot: UInt8) {
+        receiverWakeRestoreWorkItems.removeValue(forKey: slot)?.forEach { $0.cancel() }
     }
 
     func undivertAllControls() {
@@ -3204,6 +3257,7 @@ class LogiDeviceSession {
                     LogiDebugPanel.log("[\(deviceInfo.name)] Report from slot \(devIdx) (current target=\(deviceIndex)) dropped (unmanaged)")
                     return
                 }
+                noteReceiverPeripheralReport(slot: devIdx)
             }
         }
 
@@ -3930,6 +3984,9 @@ class LogiDeviceSession {
     }
 
     private func handleDivertedButtonEvent(_ report: UnsafeBufferPointer<UInt8>) {
+        if connectionMode == .receiver {
+            cancelReceiverWakeRestore(slot: deviceIndex)
+        }
         var activeCIDs: Set<UInt16> = []
         var offset = 4
         while offset + 1 < report.count {

--- a/MosTests/LogiReceiverConnectionStateTests.swift
+++ b/MosTests/LogiReceiverConnectionStateTests.swift
@@ -248,6 +248,29 @@ final class LogiReceiverConnectionStateTests: XCTestCase {
         )
     }
 
+    // MARK: - receiver idle wake detection
+
+    func testFirstReceiverReportDoesNotCountAsWake() {
+        XCTAssertFalse(LogiDeviceSession.receiverReportIndicatesWake(
+            previousTime: nil,
+            currentTime: 100
+        ))
+    }
+
+    func testReceiverReportAfterLongSilenceCountsAsWake() {
+        XCTAssertTrue(LogiDeviceSession.receiverReportIndicatesWake(
+            previousTime: 100,
+            currentTime: 160
+        ))
+    }
+
+    func testReceiverReportDuringNormalActivityDoesNotCountAsWake() {
+        XCTAssertFalse(LogiDeviceSession.receiverReportIndicatesWake(
+            previousTime: 100,
+            currentTime: 159.9
+        ))
+    }
+
     // MARK: - receiverSlotConnectionAction (Phase 4 热插拔)
 
     func testSlotConnectionDisconnectedManagedReleases() {


### PR DESCRIPTION
## Motivation

Some Logitech devices connected through a receiver can lose their temporary HID++ control diversion after being idle, without emitting the receiver's HID++ 1.0 `0x41` disconnect/reconnect notifications.

This was reproduced with a **Logitech M720 Triathlon** through a Unifying receiver:

- the M720 stopped reporting for more than five minutes;
- it resumed with a normal HID++ 2.0 peripheral report, without any slot disconnect/reconnect notification;
- Back, Forward, and MultiPlatform Gesture no longer produced diverted button events;
- manually applying Re-Divert restored the events immediately.

The existing reconnect path already restores diversion when `0x41` notifications are present, but it cannot run when the receiver continues to consider the slot connected.

### Before the fix

Relevant excerpt from the HID++ debug log (unrelated traffic omitted):

```text
[12:33:05.201] RX: 11 01 23 10 01 ...
[12:38:40.935] RX: 11 01 04 00 01 01 01 ...  # normal peripheral report after 335.7 s idle
# no slot 1 DISCONNECTED / CONNECTED notification
# Back, Forward, and Gesture produce no diverted button events
[12:40:16.310] REPROG.SetControlReporting(CID=0x00D0 MultiPlatform Gesture, divert=ON)
[12:40:16.319] REPROG.SetControlReporting(CID=0x0053 Back, divert=ON)
[12:40:16.321] REPROG.SetControlReporting(CID=0x0056 Forward, divert=ON)
[12:40:17.659] BUTTON EVENT: 0x00D0 (MultiPlatform Gesture)
```

## Reproduction

1. Connect a Logitech M720 Triathlon through a Unifying receiver.
2. Bind Back, Forward, and MultiPlatform Gesture in Mos and verify that they work.
3. Leave the M720 completely untouched for at least six minutes. A trackpad may be used during this period, but do not move or click the M720.
4. Wake the M720 by moving it, then press Back, Forward, and Gesture.
5. Before this change, the controls no longer produce diverted button events.
6. Open HID++ Debug and click Re-Divert; the controls immediately work again.

## What changed

- Track the last peripheral-report time for each managed receiver slot.
- Treat the first report after at least 60 seconds of silence as an implicit wake.
- Reapply the current binding-derived diversion state after 1 and 2 seconds, allowing the peripheral time to finish waking.
- Cancel remaining recovery work as soon as a diverted button event arrives.
- Cancel and clear pending wake recovery state during teardown.

The recovery is event-driven and bounded. It adds no polling, does not use the malformed `SetControlReporting` ACK returned by the M720 as confirmation, and does not change BLE behavior.

## Validation

- `scripts/qa/lint-logi-boundary.sh`
- `LogiReceiverConnectionStateTests`: 33 passed, 0 failed
- Full test suite: 539 total; 536 passed, 0 failed, 3 real-device tests skipped as designed
- Debug and Release arm64 builds
- Real-device validation with the M720 and Unifying receiver:
  - no `0x41` disconnect/reconnect notification occurred;
  - Mos detected the first peripheral report after approximately six minutes idle;
  - Back, Forward, and MultiPlatform Gesture were automatically diverted again;
  - Forward button events resumed without using Re-Divert;
  - the second scheduled attempt was cancelled after the first real button event.

### After the fix

Relevant excerpt from the HID++ debug log (unrelated traffic omitted):

```text
[17:11:40.173] BUTTON EVENT: all released
[17:17:52.030] RX: 11 01 04 00 01 01 01 ...  # normal peripheral report after 371.9 s idle
# no slot 1 DISCONNECTED / CONNECTED notification
[17:17:52.031] Slot 1 resumed after idle; scheduling divert restore
[17:17:53.084] REPROG.SetControlReporting(CID=0x0053 Back, divert=ON)
[17:17:53.087] REPROG.SetControlReporting(CID=0x0056 Forward, divert=ON)
[17:17:53.090] REPROG.SetControlReporting(CID=0x00D0 MultiPlatform Gesture, divert=ON)
[17:17:53.345] BUTTON EVENT: 0x0056 (Forward)
```

The full raw logs contain receiver enumeration and unrelated paired-device traffic, so they are not committed to the repository. They can be provided to reviewers if needed.

## Behavior and compatibility

This only affects managed HID++ receiver slots that have an initialized REPROG feature and active diverted bindings. The first report for a slot and normal report traffic do not trigger recovery. Existing receiver reconnect handling and BLE sessions are unchanged.

The main behavior tradeoff is that a managed receiver slot with active diverted bindings will receive a bounded re-divert after at least 60 seconds without peripheral reports, even if the idle period was not caused by sleep. `SetControlReporting` is idempotent for the desired state, and no polling or persistent timer is introduced.

