### PR TITLE
fix(logi): recover receiver slots from late activity

### DIFF
--- a/Mos/Logi/Core/LogiDeviceSession.swift
+++ b/Mos/Logi/Core/LogiDeviceSession.swift
@@ -925,6 +925,22 @@ class LogiDeviceSession {
         return .takeover(slot)
     }
 
+    /// 部分接收器不会在休眠设备恢复时发送 0x41; 离线 slot 的真实报文可作为连接证据.
+    static func receiverPeripheralActivityAction(
+        slot: UInt8,
+        wasConnected: Bool,
+        isDivertCandidate: Bool,
+        alreadyManaged: Bool
+    ) -> ReceiverSlotConnectionAction {
+        guard !wasConnected else { return .ignore }
+        return receiverSlotConnectionAction(
+            slot: slot,
+            connected: true,
+            isDivertCandidate: isDivertCandidate,
+            alreadyManaged: alreadyManaged
+        )
+    }
+
     #if DEBUG
     internal static func receiverTargetIsConnectedForTests(
         connectionMode: ConnectionMode,
@@ -1963,6 +1979,40 @@ class LogiDeviceSession {
             }
             NotificationCenter.default.post(name: LogiSessionManager.sessionChangedNotification, object: nil)
         }
+    }
+
+    /// 初始枚举时设备可能仍在休眠且之后不补发 0x41. 第一条真实 peripheral 报文将 slot
+    /// 标记为在线并直接复用现有 takeover 队列; 已在线 slot 的后续报文不会重复触发.
+    private func handleReceiverPeripheralActivity(slot: UInt8) -> Bool {
+        guard slot >= 1 && slot <= 6, handshakeComplete, receiverEnumPhase != 1 else { return false }
+
+        guard let idx = receiverPairedDevices.firstIndex(where: { $0.slot == slot }) else { return false }
+        let wasConnected = receiverPairedDevices[idx].isConnected
+        receiverPairedDevices[idx].isConnected = true
+        receiverPairedDevices[idx].lastError = nil
+
+        guard !wasConnected else { return false }
+
+        let device = receiverPairedDevices.first(where: { $0.slot == slot })
+        let bindingsExist = !LogiCenter.shared.registry.aggregatedCacheIsEmpty
+        let isDivertCandidate = !Self.receiverNonDivertDeviceTypes.contains(device?.deviceType ?? 0)
+            && bindingsExist
+        let action = Self.receiverPeripheralActivityAction(
+            slot: slot,
+            wasConnected: wasConnected,
+            isDivertCandidate: isDivertCandidate,
+            alreadyManaged: receiverManagedSlots.contains(slot)
+        )
+        LogiDebugPanel.log(
+            "[\(deviceInfo.name)] Inferred slot \(slot) connection from peripheral activity; candidate=\(isDivertCandidate) -> \(action)"
+        )
+        NotificationCenter.default.post(name: LogiSessionManager.sessionChangedNotification, object: nil)
+
+        if case .takeover(let takeoverSlot) = action {
+            handleReceiverSlotTakeover(slot: takeoverSlot)
+            return true
+        }
+        return false
     }
 
     /// 去抖调度 takeover: 每次 0x41 连接重置定时器, 该 slot 稳定在线 debounce 窗口后才真正接管.
@@ -3184,6 +3234,12 @@ class LogiDeviceSession {
             // Ping response from device behind receiver (IRoot function 1)
             if devIdx >= 1 && devIdx <= 6 && featureIdx == 0x00 && functionId == 1 && pendingSlotPings.contains(devIdx) {
                 handleSlotPingResponse(devIdx: devIdx, report: report)
+                return
+            }
+
+            // 部分接收器不会为初始扫描时休眠的设备补发 0x41. 第一条真实报文足以证明 slot 在线;
+            // takeover 启动后丢弃该条尚无可靠 feature 映射的报文, 后续报文走正常路由.
+            if handleReceiverPeripheralActivity(slot: devIdx) {
                 return
             }
 

--- a/Mos/Logi/Core/LogiDeviceSession.swift
+++ b/Mos/Logi/Core/LogiDeviceSession.swift
@@ -1988,10 +1988,10 @@ class LogiDeviceSession {
 
         guard let idx = receiverPairedDevices.firstIndex(where: { $0.slot == slot }) else { return false }
         let wasConnected = receiverPairedDevices[idx].isConnected
+        guard !wasConnected else { return false }
+
         receiverPairedDevices[idx].isConnected = true
         receiverPairedDevices[idx].lastError = nil
-
-        guard !wasConnected else { return false }
 
         let device = receiverPairedDevices.first(where: { $0.slot == slot })
         let bindingsExist = !LogiCenter.shared.registry.aggregatedCacheIsEmpty
@@ -2009,7 +2009,7 @@ class LogiDeviceSession {
         NotificationCenter.default.post(name: LogiSessionManager.sessionChangedNotification, object: nil)
 
         if case .takeover(let takeoverSlot) = action {
-            handleReceiverSlotTakeover(slot: takeoverSlot)
+            scheduleReceiverSlotTakeover(slot: takeoverSlot)
             return true
         }
         return false

--- a/MosTests/LogiReceiverConnectionStateTests.swift
+++ b/MosTests/LogiReceiverConnectionStateTests.swift
@@ -306,4 +306,17 @@ final class LogiReceiverConnectionStateTests: XCTestCase {
             .ignore
         )
     }
+
+    func testPeripheralActivityTakesOverPreviouslyOfflineSlotOnce() {
+        XCTAssertEqual(
+            LogiDeviceSession.receiverPeripheralActivityAction(
+                slot: 1, wasConnected: false, isDivertCandidate: true, alreadyManaged: false),
+            .takeover(1)
+        )
+        XCTAssertEqual(
+            LogiDeviceSession.receiverPeripheralActivityAction(
+                slot: 1, wasConnected: true, isDivertCandidate: true, alreadyManaged: false),
+            .ignore
+        )
+    }
 }


### PR DESCRIPTION
## Motivation

When a receiver reconnects while a paired mouse is asleep, the initial slot scan can finish with no connected devices. Some devices then resume by sending normal peripheral traffic without a receiver `0x41` connection notification, so Mos never enumerates or takes over that slot.

This was reproduced with a **Logitech M720 Triathlon** through a Unifying receiver:

- the receiver was reconnected while the M720 was powered off;
- the initial scan completed with `0/6` connected slots;
- after the M720 was powered on, it sent valid HID++ peripheral reports without `0x41`;
- Back, Forward, and MultiPlatform Gesture continued through their native HID paths;
- restarting Mos while the M720 was awake made the controls work again.

This is separate from #1012: that PR restores diversion for a slot Mos already manages, while this bug leaves the late device entirely unmanaged.

## Reproduction

1. Start Mos with the receiver connected and the M720 bindings configured.
2. Power off the Logitech M720 Triathlon.
3. Unplug and reconnect the USB receiver.
4. Wait at least six seconds, until the log shows `Ping complete: 0/6 slots connected` and `No devices found on receiver`.
5. Power on the M720 and move it, then press Back, Forward, and Gesture.
6. Before this change, Mos never takes over slot 1 and the controls use their native HID behavior.
7. Restarting Mos while the M720 is awake makes the controls work again.

## Root cause

Receiver peripheral reports were routed only against the current and managed slot sets. Traffic from a slot that the startup scan had marked offline did not update `receiverPairedDevices` or enter the existing takeover queue. Slot 1 was especially easy to miss because it is also the temporary default routing cursor.

## What changed

- Treat the first valid peripheral report from a previously offline slot, after receiver enumeration has completed, as an implicit connection signal.
- Mark that slot online and reuse the existing serialized takeover/discovery path.
- Drop the triggering report because its feature index cannot be interpreted reliably before discovery completes.
- Ignore subsequent traffic once the slot is online, preventing repeated discovery.

The recovery is event-driven. It adds no polling or persistent timer and does not change BLE behavior or stored settings. On receivers that cannot report device type, an unknown slot may receive the same one-time discovery already used during normal startup; non-mouse controls are then excluded by the existing Left/Right CID check.

## Validation

- `scripts/qa/lint-logi-boundary.sh`
- `LogiReceiverConnectionStateTests`: 31 passed, 0 failed
- Debug build
- Real-device validation with the M720 and Unifying receiver:
  - initial enumeration completed with `0/6` slots connected;
  - no receiver `0x41` notification followed;
  - the first M720 peripheral report triggered exactly one slot 1 takeover;
  - discovery completed and re-enabled diversion for Back, Forward, and MultiPlatform Gesture in about 0.5 seconds;
  - all three controls subsequently produced their expected diverted button events;
  - a paired keyboard was discovered once, identified as non-mouse, and remained unmanaged.

### Relevant log excerpt

```text
[23:18:03.409] Ping complete: 0/6 slots connected
[23:18:03.409] No devices found on receiver
[23:18:18.120] RX: 11 01 04 00 01 01 01 ...
[23:18:18.121] Inferred slot 1 connection from peripheral activity; candidate=true -> takeover(1)
[23:18:18.122] Slot 1 (re)connected; queued for takeover
[23:18:18.620] CID 0x0056 divert=ON
[23:18:18.623] CID 0x00D0 divert=ON
[23:18:18.626] CID 0x0053 divert=ON
[23:18:18.629] Takeover sweep complete: managed=[1] cursor=1 (mouse)
[23:18:24.400] Button DISPATCH: CID 0x00D0 code=2208 phase=down result=consumed
[23:18:27.382] Button DISPATCH: CID 0x0056 code=1007 phase=down result=consumed
[23:18:28.128] Button DISPATCH: CID 0x0053 code=1006 phase=down result=consumed
```

The full raw logs contain unrelated paired-device traffic, so they are not committed to the repository. They can be provided to reviewers if needed.

