### PR TITLE
fix(application): stop gating per-app scroll rules on global switches

### DIFF
--- a/Mos.xcodeproj/project.pbxproj
+++ b/Mos.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0BE5A292253A1168006D61C0 /* LoginServiceKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0BE5A291253A1168006D61C0 /* LoginServiceKit */; };
 		0BE5A296253A119C006D61C0 /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = 0BE5A295253A119C006D61C0 /* DGCharts */; };
 		0BE5A29A2F7A1C5B006D61C0 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 0BE5A29B2F7A1C5B006D61C0 /* Sparkle */; };
+		AA1011FB00000000000000B2 /* MosTests/ScrollTargetApplicationRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1011FA00000000000000B1 /* MosTests/ScrollTargetApplicationRulesTests.swift */; };
 		0E590C87FC41F66FF48D518F /* MosTests/ScrollDispatchContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DD10CB06A5D177E3BD0845 /* MosTests/ScrollDispatchContextTests.swift */; };
 		296126EA068FF77D423ACAA9 /* MosTests/ScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B8B50E951D72C6195DBA3A /* MosTests/ScrollEventTests.swift */; };
 		568F976CF65380A55E73E588 /* MosTests/ScrollHotkeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D69BB23DED610DCD5A0103 /* MosTests/ScrollHotkeyTests.swift */; };
@@ -73,6 +74,7 @@
 		0B2C591D2F7ADB79003D88C9 /* Debug.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Debug.xctestplan; sourceTree = "<group>"; };
 		22142DA01E25344E00E4BFBF /* Mos Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mos Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		25DD10CB06A5D177E3BD0845 /* MosTests/ScrollDispatchContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollDispatchContextTests.swift; sourceTree = SOURCE_ROOT; };
+		AA1011FA00000000000000B1 /* MosTests/ScrollTargetApplicationRulesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollTargetApplicationRulesTests.swift; sourceTree = SOURCE_ROOT; };
 		2D6CF5441214A14BB8FFEDA5 /* MosTests/ScrollCoreHotkeyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollCoreHotkeyTests.swift; sourceTree = SOURCE_ROOT; };
 		2F59E07FB2E69806EAED5405 /* MosTests/ScrollPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollPhaseTests.swift; sourceTree = SOURCE_ROOT; };
 		31AFD832EF49533E8168BAA0 /* MosTests/ScrollFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MosTests/ScrollFilterTests.swift; sourceTree = SOURCE_ROOT; };
@@ -166,6 +168,7 @@
 				F00A00000000000000000002 /* MosTests/OpenTargetPayloadTests.swift */,
 				F00A00000000000000000004 /* MosTests/OptionsButtonsLoaderTests.swift */,
 				F00A00000000000000000006 /* MosTests/ShortcutExecutorOpenTargetTests.swift */,
+				AA1011FA00000000000000B1 /* MosTests/ScrollTargetApplicationRulesTests.swift */,
 				A1B2C3D4E5F6A7B8C9D0E1F3 /* MosTests/ButtonBindingTests.swift */,
 				B2C3D4E5F6A7B8C9D0E1F201 /* MosTests/ButtonUtilsCacheTests.swift */,
 				C4E5F6A7B8C9D0E1F3020201 /* MosTests/ButtonCapturePresentationStatusTests.swift */,
@@ -379,6 +382,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F00A00000000000000000001 /* MosTests/OpenTargetPayloadTests.swift in Sources */,
+				AA1011FB00000000000000B2 /* MosTests/ScrollTargetApplicationRulesTests.swift in Sources */,
 				F00A00000000000000000003 /* MosTests/OptionsButtonsLoaderTests.swift in Sources */,
 				F00A00000000000000000005 /* MosTests/ShortcutExecutorOpenTargetTests.swift in Sources */,
 				FECC8D1CC04A0A99B1E1A8EB /* MosTests/InterpolatorTests.swift in Sources */,

--- a/Mos/Windows/PreferencesWindow/ApplicationView/Application.swift
+++ b/Mos/Windows/PreferencesWindow/ApplicationView/Application.swift
@@ -79,38 +79,30 @@ extension Application {
         return inherit ? Options.shared.scroll.durationTransition : scroll.durationTransition
     }
     // 功能
+    // inherit=on 时 resolvedScrollOptions() 即全局配置, 结果与全局路径一致;
+    // inherit=off 时完全使用应用自身配置, 不再受全局开关联动 (见 #1011)
     func isSmooth(_ block: Bool) -> Bool {
         if block { return false }
-        if !Options.shared.scroll.smooth { return false }
         return resolvedScrollOptions().smooth
     }
     func isReverse() -> Bool {
-        if !Options.shared.scroll.reverse { return false }
         return resolvedScrollOptions().reverse
     }
     func isReverseVertical() -> Bool {
-        if !Options.shared.scroll.reverse { return false }
-        if !Options.shared.scroll.reverseVertical { return false }
         let target = resolvedScrollOptions()
         return target.reverse && target.reverseVertical
     }
     func isReverseHorizontal() -> Bool {
-        if !Options.shared.scroll.reverse { return false }
-        if !Options.shared.scroll.reverseHorizontal { return false }
         let target = resolvedScrollOptions()
         return target.reverse && target.reverseHorizontal
     }
     func isSmoothVertical(_ block: Bool) -> Bool {
         if block { return false }
-        if !Options.shared.scroll.smooth { return false }
-        if !Options.shared.scroll.smoothVertical { return false }
         let target = resolvedScrollOptions()
         return target.smooth && target.smoothVertical
     }
     func isSmoothHorizontal(_ block: Bool) -> Bool {
         if block { return false }
-        if !Options.shared.scroll.smooth { return false }
-        if !Options.shared.scroll.smoothHorizontal { return false }
         let target = resolvedScrollOptions()
         return target.smooth && target.smoothHorizontal
     }

--- a/MosTests/ScrollTargetApplicationRulesTests.swift
+++ b/MosTests/ScrollTargetApplicationRulesTests.swift
@@ -1,0 +1,177 @@
+//
+//  ScrollTargetApplicationRulesTests.swift
+//  MosTests
+//
+//  #1011 回归测试: 关闭 "继承全局设定" 后, 按应用配置的平滑/翻转
+//  不应再被全局开关联动压制; 继承开启时仍与全局保持一致。
+//
+
+import XCTest
+@testable import Mos_Debug
+
+final class ScrollTargetApplicationRulesTests: XCTestCase {
+
+    // 仅快照本测试会改动的开关 (OPTIONS_SCROLL_DEFAULT 是 class, 引用快照无法回滚变更)
+    private var savedGlobalSmooth = false
+    private var savedGlobalSmoothVertical = false
+    private var savedGlobalSmoothHorizontal = false
+    private var savedGlobalReverse = false
+    private var savedGlobalReverseVertical = false
+    private var savedGlobalReverseHorizontal = false
+
+    override func setUp() {
+        super.setUp()
+        // 保存全局滚动开关 (XCTest 下 markChanged 不落盘, 只影响内存)
+        savedGlobalSmooth = Options.shared.scroll.smooth
+        savedGlobalSmoothVertical = Options.shared.scroll.smoothVertical
+        savedGlobalSmoothHorizontal = Options.shared.scroll.smoothHorizontal
+        savedGlobalReverse = Options.shared.scroll.reverse
+        savedGlobalReverseVertical = Options.shared.scroll.reverseVertical
+        savedGlobalReverseHorizontal = Options.shared.scroll.reverseHorizontal
+    }
+
+    override func tearDown() {
+        // 还原全局滚动开关
+        Options.shared.scroll.smooth = savedGlobalSmooth
+        Options.shared.scroll.smoothVertical = savedGlobalSmoothVertical
+        Options.shared.scroll.smoothHorizontal = savedGlobalSmoothHorizontal
+        Options.shared.scroll.reverse = savedGlobalReverse
+        Options.shared.scroll.reverseVertical = savedGlobalReverseVertical
+        Options.shared.scroll.reverseHorizontal = savedGlobalReverseHorizontal
+        super.tearDown()
+    }
+
+    /// 构造一个不进入持久化列表的独立 Application 对象
+    private func makeApplication(inherit: Bool) -> Application {
+        let application = Application(path: "/Applications/RegressionTest.app")
+        application.inherit = inherit
+        return application
+    }
+
+    // MARK: - #1011: 全局关闭时, 按应用开启的规则必须生效
+
+    func testPerAppSmoothAppliesWhenGlobalSmoothOff() {
+        Options.shared.scroll.smooth = false
+        Options.shared.scroll.smoothVertical = false
+        Options.shared.scroll.smoothHorizontal = false
+        let application = makeApplication(inherit: false)
+        application.scroll.smooth = true
+
+        XCTAssertTrue(application.isSmooth(false), "per-app smooth=ON must apply when global smooth is OFF (#1011)")
+        XCTAssertTrue(application.isSmoothVertical(false), "per-app axis smooth must not be gated by global axis switches")
+        XCTAssertTrue(application.isSmoothHorizontal(false), "per-app axis smooth must not be gated by global axis switches")
+    }
+
+    func testPerAppReverseAppliesWhenGlobalReverseOff() {
+        Options.shared.scroll.reverse = false
+        Options.shared.scroll.reverseVertical = false
+        Options.shared.scroll.reverseHorizontal = false
+        let application = makeApplication(inherit: false)
+        application.scroll.reverse = true
+
+        XCTAssertTrue(application.isReverse(), "per-app reverse=ON must apply when global reverse is OFF (#1011)")
+        XCTAssertTrue(application.isReverseVertical(), "per-app axis reverse must not be gated by global axis switches")
+        XCTAssertTrue(application.isReverseHorizontal(), "per-app axis reverse must not be gated by global axis switches")
+    }
+
+    // MARK: - #1011 另一半语义: 全局开启时, 按应用关闭的规则也必须生效
+
+    func testPerAppDisableAppliesWhenGlobalSwitchesOn() {
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.smoothVertical = true
+        Options.shared.scroll.smoothHorizontal = true
+        Options.shared.scroll.reverse = true
+        Options.shared.scroll.reverseVertical = true
+        Options.shared.scroll.reverseHorizontal = true
+        let application = makeApplication(inherit: false)
+        application.scroll.smooth = false
+        application.scroll.reverse = false
+
+        XCTAssertFalse(application.isSmooth(false), "per-app smooth=OFF must disable smoothing when global smooth is ON")
+        XCTAssertFalse(application.isSmoothVertical(false), "per-app smooth=OFF must disable axis smoothing")
+        XCTAssertFalse(application.isSmoothHorizontal(false), "per-app smooth=OFF must disable axis smoothing")
+        XCTAssertFalse(application.isReverseVertical(), "per-app reverse=OFF must disable vertical reverse when global reverse is ON")
+        XCTAssertFalse(application.isReverseHorizontal(), "per-app reverse=OFF must disable horizontal reverse when global reverse is ON")
+    }
+
+    // MARK: - 继承语义: inherit=on 时仍与全局一致
+
+    func testInheritStillMirrorsGlobalSwitches() {
+        Options.shared.scroll.smooth = false
+        Options.shared.scroll.reverse = false
+        let inheriting = makeApplication(inherit: true)
+        XCTAssertFalse(inheriting.isSmooth(false), "inherit=ON must follow global smooth=OFF")
+        XCTAssertFalse(inheriting.isReverseVertical(), "inherit=ON must follow global reverse=OFF")
+
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.reverse = true
+        Options.shared.scroll.reverseVertical = true
+        XCTAssertTrue(inheriting.isSmooth(false), "inherit=ON must follow global smooth=ON")
+        XCTAssertTrue(inheriting.isReverseVertical(), "inherit=ON must follow global reverse=ON")
+    }
+
+    // MARK: - 独立配置内部的从属关系仍然生效
+
+    func testOwnAxisTogglesStillGateWithinApplicationOptions() {
+        Options.shared.scroll.smooth = true
+        Options.shared.scroll.reverse = true
+        let application = makeApplication(inherit: false)
+        application.scroll.smooth = true
+        application.scroll.reverse = true
+        application.scroll.smoothVertical = false
+        application.scroll.reverseVertical = false
+
+        XCTAssertFalse(application.isSmoothVertical(false), "own smoothVertical=OFF must disable vertical smoothing")
+        XCTAssertTrue(application.isSmoothHorizontal(false), "own smoothHorizontal default ON must stay ON")
+        XCTAssertFalse(application.isReverseVertical(), "own reverseVertical=OFF must disable vertical reverse")
+        XCTAssertTrue(application.isReverseHorizontal(), "own reverseHorizontal default ON must stay ON")
+    }
+
+    // MARK: - 禁用平滑热键仍然优先
+
+    func testBlockHotkeyStillSuppressesSmooth() {
+        Options.shared.scroll.smooth = true
+        let application = makeApplication(inherit: false)
+        application.scroll.smooth = true
+
+        XCTAssertFalse(application.isSmooth(true), "block hotkey must suppress per-app smoothing")
+        XCTAssertFalse(application.isSmoothVertical(true), "block hotkey must suppress per-app axis smoothing")
+    }
+
+    // MARK: - 匹配链: 两种添加方式保存的路径都能命中运行中应用
+
+    func testGetTargetApplicationMatchesBothPickStyles() throws {
+        let current = NSRunningApplication.current
+        guard let executablePath = current.executableURL?.path,
+              let bundlePath = current.bundleURL?.path else {
+            throw XCTSkip("No resolvable executable/bundle path in this environment")
+        }
+        let applications = Options.shared.application.applications
+        // 若本机配置已存在匹配宿主应用的条目, 跳过 (无法断言干净的初始状态)
+        guard ScrollUtils.shared.getTargetApplication(from: current) == nil else {
+            throw XCTSkip("A pre-existing applications entry matches the test host")
+        }
+
+        // 运行中应用列表添加: 保存可执行文件路径
+        applications.append(Application(path: executablePath))
+        defer { applications.remove(from: executablePath) }
+        XCTAssertNotNil(
+            ScrollUtils.shared.getTargetApplication(from: current),
+            "running-app pick (executable path) must match the event-time lookup"
+        )
+        // 移除后再验证 Bundle 路径, 避免经由可执行路径的回退匹配误通过
+        applications.remove(from: executablePath)
+
+        // 文件面板添加: 保存 Bundle 路径
+        applications.append(Application(path: bundlePath))
+        defer { applications.remove(from: bundlePath) }
+        XCTAssertNotNil(
+            ScrollUtils.shared.getTargetApplication(from: current),
+            "file-panel pick (bundle path) must match the event-time lookup"
+        )
+        applications.remove(from: bundlePath)
+
+        // 未添加的其他路径不应命中
+        XCTAssertNil(ScrollUtils.shared.getTargetApplication(from: current))
+    }
+}


### PR DESCRIPTION
## Summary

Per-application scroll rules (目标应用程序) had no effect when they *enabled* smooth scrolling or reverse scrolling while the corresponding global switch was off — for any application (#1011).

## Root cause

`Application.isSmooth / isReverse*` gate their result on the **global** master switches (`Application.swift`, e.g. `if !Options.shared.scroll.smooth { return false }`), a leftover of the old "Exception" module where per-app entries could only restrict global behavior. The per-app UI, however, presents fully independent toggles once 继承全局设定 is unchecked (`ScrollOptionsContextProviding.swift:19-23`, `PreferencesScrollingViewController.swift:190-198`), so an enabled per-app rule was silently forced off — while the panel kept displaying it as enabled.

The event → target-PID → path matching chain is not at fault: on macOS 26, a probe with an event tap in Mos's exact configuration shows `eventTargetUnixProcessID` populated, and both add-app flows produce paths the lookup already matches (running-app pick stores the executable path, file-panel pick stores the bundle path; `getTargetApplication` tries both). A regression test now pins that matching chain as well.

## Changes

- Drop the global master gates from `Application.isSmooth / isReverse / isSmoothVertical / isSmoothHorizontal / isReverseVertical / isReverseHorizontal`; the inherit-aware `resolvedScrollOptions()` is now the single source of truth.
- New regression tests (`MosTests/ScrollTargetApplicationRulesTests.swift`, 7 tests): per-app enable with globals off (fails on master), per-app disable with globals on, inherit still mirroring global, block hotkey still winning, own-axis sub-toggles, and bundle/executable path matching for both add-app flows.

## Behavior changes / compatibility

- Only observable change: a listed app with 继承全局设定 unchecked and its own 平滑滚动/翻转滚轮方向 enabled now actually gets smoothing/reversing even when the corresponding global switch is off (previously forced off — the bug). The same independence applies to the per-app axis sub-toggles, consistent with "inherit off = full replacement" and with what the per-app panel already displays.
- Entries with inherit checked, unlisted apps, the global code path, allowlist mode and the block hotkey behave exactly as before — verified by an exhaustive old-vs-new comparison over the full input space (divergence exists only at `inherit=false ∧ own setting ON ∧ corresponding global switch OFF`, and is strictly false→true).

## Verification

- `xcodebuild -project Mos.xcodeproj -scheme Debug -configuration Debug build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=` → `** BUILD SUCCEEDED **`, exit 0
- `xcodebuild -project Mos.xcodeproj -scheme Debug -configuration Debug test -testPlan Debug …` → `Executed 543 tests, with 3 tests skipped and 0 failures` (536 pre-existing + 7 new)
- Red-before-green: with the fix reverted, the two direction-pinning tests fail on master's gated implementation; with the fix, 7/7 pass.

Closes #1011
